### PR TITLE
libretro: Make load_game() return a valid loading succes state

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -676,10 +676,10 @@ bool retro_load_game(const struct retro_game_info *info)
    yinit.usethreads = 0;
 #endif
 
-   YabauseInit(&yinit);
+   int result = YabauseInit(&yinit);
    YabauseSetDecilineMode(1);
 
-   return true;
+   return !result;
 }
 
 bool retro_load_game_special(unsigned game_type, const struct retro_game_info *info, size_t num_info)


### PR DESCRIPTION
This makes retro_load_game() return true if the game have been
successfuly loaded, and false otherwise, as expected.
