### PR TITLE
Report git version with library_version

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -33,6 +33,10 @@ CORE_DIR := .
 
 TARGET_NAME = yabause
 CC_AS ?= $(CC)
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 # Unix
 ifneq (,$(findstring unix,$(platform)))

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -3,6 +3,11 @@ DYNAREC := 0
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 APP_DIR := ../../src
 
 LOCAL_MODULE    := retro

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -437,7 +437,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "Yabause";
-   info->library_version  = "v0.9.14";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = "v0.9.14" GIT_VERSION;
    info->need_fullpath    = true;
    info->valid_extensions = "bin|cue|iso";
 }


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.