### PR TITLE
Applying "no music" fix from Yabause

### DIFF
--- a/yabause/src/cs2.c
+++ b/yabause/src/cs2.c
@@ -83,7 +83,7 @@ static INLINE void doCDReport(u8 status)
    Cs2Area->reg.CR1 = (status << 8) | ((Cs2Area->options & 0xF) << 4) | (Cs2Area->repcnt & 0xF);
    Cs2Area->reg.CR2 = (Cs2Area->ctrladdr << 8) | Cs2Area->track;
    Cs2Area->reg.CR3 = (u16)((Cs2Area->index << 8) | ((Cs2Area->FAD >> 16) & 0xFF));
-   Cs2Area->reg.CR4 = (u16) Cs2Area->FAD; 
+   Cs2Area->reg.CR4 = (u16) Cs2Area->FAD;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -93,7 +93,7 @@ static INLINE void doMPEGReport(u8 status)
    Cs2Area->reg.CR1 = (status << 8) | Cs2Area->actionstatus;
    Cs2Area->reg.CR2 = Cs2Area->vcounter;
    Cs2Area->reg.CR3 = (Cs2Area->pictureinfo << 8) | Cs2Area->mpegaudiostatus;
-   Cs2Area->reg.CR4 = Cs2Area->mpegvideostatus; 
+   Cs2Area->reg.CR4 = Cs2Area->mpegvideostatus;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -140,7 +140,7 @@ u16 FASTCALL Cs2ReadWord(u32 addr) {
 
 //                  CDLOG("cs2\t: Hirq read, Hirq mask = %x - ret: %x\n", Memory::getWord(0x9000C), val);
                   return val;
-    case 0x9000C: 
+    case 0x9000C:
     case 0x9000E: return Cs2Area->reg.HIRQMASK;
     case 0x90018:
     case 0x9001A: return Cs2Area->reg.CR1;
@@ -258,10 +258,10 @@ void FASTCALL Cs2WriteWord(u32 addr, u16 val) {
     case 0x9000A:
                   Cs2Area->reg.HIRQ &= val;
                   return;
-    case 0x9000C: 
+    case 0x9000C:
     case 0x9000E: Cs2Area->reg.HIRQMASK = val;
                   return;
-    case 0x90018: 
+    case 0x90018:
     case 0x9001A: Cs2Area->status &= ~CDB_STAT_PERI;
                   Cs2Area->_command = 1;
                   Cs2Area->reg.CR1 = val;
@@ -453,7 +453,7 @@ void FASTCALL Cs2RapidCopyT1(void *dest, u32 count)
       }
    }
 
-   if (count > 0)    
+   if (count > 0)
    {
       // We tried to copy more data than was stored, so fill the rest of
       // the buffer with dummy data
@@ -545,7 +545,7 @@ void FASTCALL Cs2RapidCopyT2(void *dest, u32 count)
       }
    }
 
-   if (count > 0)    
+   if (count > 0)
    {
       memset(dest32, 0xCD, count*4);
    }
@@ -664,7 +664,7 @@ void Cs2Reset(void) {
 
   switch (Cs2Area->cdi->GetStatus())
   {
-     case 0:   
+     case 0:
      case 1:
              Cs2Area->status = CDB_STAT_PAUSE;
              Cs2Area->FAD = 150;
@@ -789,11 +789,11 @@ void Cs2Reset(void) {
   Cs2Area->mpegcon[1].audbufnum = Cs2Area->mpegcon[1].vidbufnum = 0xFF;
 
   // should verify the following
-  Cs2Area->mpegstm[0].audstm = Cs2Area->mpegstm[0].vidstm = 0x00; 
-  Cs2Area->mpegstm[0].audstmid = Cs2Area->mpegstm[0].vidstmid = 0x00; 
-  Cs2Area->mpegstm[0].audchannum = Cs2Area->mpegstm[0].vidchannum = 0x00; 
+  Cs2Area->mpegstm[0].audstm = Cs2Area->mpegstm[0].vidstm = 0x00;
+  Cs2Area->mpegstm[0].audstmid = Cs2Area->mpegstm[0].vidstmid = 0x00;
+  Cs2Area->mpegstm[0].audchannum = Cs2Area->mpegstm[0].vidchannum = 0x00;
   Cs2Area->mpegstm[1].audstm = Cs2Area->mpegstm[1].vidstm = 0x00;
-  Cs2Area->mpegstm[1].audstmid = Cs2Area->mpegstm[1].vidstmid = 0x00; 
+  Cs2Area->mpegstm[1].audstmid = Cs2Area->mpegstm[1].vidstmid = 0x00;
   Cs2Area->mpegstm[1].audchannum = Cs2Area->mpegstm[1].vidchannum = 0x00;
 }
 
@@ -844,7 +844,7 @@ void Cs2Exec(u32 timing) {
 
    if (Cs2Area->_periodiccycles >= Cs2Area->_periodictiming)
    {
-      Cs2Area->_periodiccycles -= Cs2Area->_periodictiming; 
+      Cs2Area->_periodiccycles -= Cs2Area->_periodictiming;
 
       // Get Drive's current status and compare with old status
       switch (Cs2Area->status & 0xF) {
@@ -916,7 +916,7 @@ void Cs2Exec(u32 timing) {
 
                            if (Cs2Area->playtype == CDB_PLAYTYPE_FILE)
                               Cs2Area->reg.HIRQ |= CDB_HIRQ_EFLS;
- 
+
                            CDLOG("PLAY HAS ENDED\n");
                         }
                         else {
@@ -1198,7 +1198,7 @@ void Cs2Execute(void) {
       CDLOG("cs2\t: Command: mpegSetInterruptMask %04x %04x %04x\n", Cs2Area->reg.HIRQ, Cs2Area->reg.CR1, Cs2Area->reg.CR2);
       Cs2MpegSetInterruptMask();
       break;
-    case 0x93: 
+    case 0x93:
       CDLOG("cs2\t: Command: mpegInit %04x %04x %04x\n", Cs2Area->reg.HIRQ, Cs2Area->reg.CR1, Cs2Area->reg.CR2);
       Cs2MpegInit();
       break;
@@ -1214,7 +1214,7 @@ void Cs2Execute(void) {
       CDLOG("cs2\t: Command: mpegSetDecodingMethod %04x %04x %04x %04x\n", Cs2Area->reg.HIRQ, Cs2Area->reg.CR1, Cs2Area->reg.CR2, Cs2Area->reg.CR4);
       Cs2MpegSetDecodingMethod();
       break;
-    case 0x9A:      
+    case 0x9A:
       CDLOG("cs2\t: Command: mpegSetConnection %04x %04x %04x %04x %04x\n", Cs2Area->reg.HIRQ, Cs2Area->reg.CR1, Cs2Area->reg.CR2, Cs2Area->reg.CR3, Cs2Area->reg.CR4);
       Cs2MpegSetConnection();
       break;
@@ -1314,7 +1314,7 @@ void Cs2GetToc(void) {
   Cs2Area->reg.CR1 = Cs2Area->status << 8;
   Cs2Area->reg.CR2 = 0xCC;
   Cs2Area->reg.CR3 = 0x0;
-  Cs2Area->reg.CR4 = 0x0; 
+  Cs2Area->reg.CR4 = 0x0;
   Cs2Area->reg.HIRQ |= CDB_HIRQ_CMOK | CDB_HIRQ_DRDY;
   Cs2Area->status = CDB_STAT_PAUSE;
 }
@@ -1486,7 +1486,7 @@ void Cs2PlayDisc(void) {
         // Move pickup to start position
         Cs2Area->FAD = Cs2Area->playFAD;
   }
-  else 
+  else
   {
      // Track Mode
 
@@ -1526,6 +1526,8 @@ void Cs2PlayDisc(void) {
   }
   else if (pdepos != 0)
   {
+     // To the next track (Fixes "no music" in games like Sega Rally)
+     pdepos += 0x100;
      // Track Mode
      if ((pdepos & 0xFF) == 0)
         Cs2Area->playendFAD = Cs2TrackToFAD((u16)(pdepos | 0x0063));
@@ -1573,7 +1575,7 @@ void Cs2SeekDisc(void) {
 			 break;
 		 }
 	 }
-		 
+
   }
   else
   {
@@ -1624,14 +1626,14 @@ void Cs2GetSubcodeQRW(void) {
              rel_fad = Cs2Area->FAD-(Cs2Area->TOC[Cs2Area->track-1] & 0xFFFFFF);
              Cs2FADToMSF(rel_fad, &rel_m, &rel_s, &rel_f);
              Cs2FADToMSF(Cs2Area->FAD, &m, &s, &f);
-             
+
              Cs2Area->transscodeq[0] = Cs2Area->ctrladdr; // ctl/adr
              Cs2Area->transscodeq[1] = ToBCD(Cs2Area->track); // track number
              Cs2Area->transscodeq[2] = ToBCD(Cs2Area->index); // index
              Cs2Area->transscodeq[3] = ToBCD(rel_m); // relative M
              Cs2Area->transscodeq[4] = ToBCD(rel_s); // relative S
              Cs2Area->transscodeq[5] = ToBCD(rel_f); // relative F
-             Cs2Area->transscodeq[6] = 0; 
+             Cs2Area->transscodeq[6] = 0;
              Cs2Area->transscodeq[7] = ToBCD(m); // M
              Cs2Area->transscodeq[8] = ToBCD(s); // S
              Cs2Area->transscodeq[9] = ToBCD(f); // F
@@ -1694,7 +1696,7 @@ void Cs2SetCDDeviceConnection(void) {
 void Cs2GetLastBufferDestination(void) {
   Cs2Area->reg.CR1 = (Cs2Area->status << 8);
   Cs2Area->reg.CR2 = 0;
-  Cs2Area->reg.CR3 = Cs2Area->lastbuffer << 8; 
+  Cs2Area->reg.CR3 = Cs2Area->lastbuffer << 8;
   Cs2Area->reg.CR4 = 0;
   Cs2Area->reg.HIRQ |= CDB_HIRQ_CMOK;
 }
@@ -1836,7 +1838,7 @@ void Cs2ResetSelector(void) {
      }
 
      if (Cs2Area->blockfreespace > 0) Cs2Area->isbufferfull = 0;
-     if (Cs2Area->blockfreespace == 200) 
+     if (Cs2Area->blockfreespace == 200)
      {
         Cs2Area->isonesectorstored = 0;
         Cs2Area->datatranstype = -1;
@@ -2058,7 +2060,7 @@ static INLINE void CalcSectorOffsetNumber(u32 bufno, u32 *sectoffset, u32 *sectn
 {
    if (*sectoffset == 0xFFFF)
    {
-      // Last sector 
+      // Last sector
       CDLOG("FIXME - Sector offset of 0xFFFF not supported\n");
    }
    else if (*sectnum == 0xFFFF)
@@ -2427,7 +2429,7 @@ void Cs2MpegInit(void) {
 
   // double-check this
   if (Cs2Area->reg.CR2 == 0x0001) // software timer/reset?
-     Cs2Area->reg.HIRQ |= CDB_HIRQ_CMOK | CDB_HIRQ_MPCM | CDB_HIRQ_MPED | CDB_HIRQ_MPST; 
+     Cs2Area->reg.HIRQ |= CDB_HIRQ_CMOK | CDB_HIRQ_MPCM | CDB_HIRQ_MPED | CDB_HIRQ_MPST;
   else
      Cs2Area->reg.HIRQ |= CDB_HIRQ_CMOK | CDB_HIRQ_MPED | CDB_HIRQ_MPST;
 
@@ -2668,7 +2670,7 @@ void Cs2AuthenticateDevice(void) {
         Cs2Area->mpgauth = 2;
      }
      else
-     {     
+     {
         // if authentication passes(obviously it always does), CDB_HIRQ_CSCT is set
         Cs2Area->isonesectorstored = 1;
         Cs2Area->reg.HIRQ |= CDB_HIRQ_EFLS | CDB_HIRQ_CSCT;
@@ -2775,7 +2777,7 @@ u8 Cs2FADToTrack(u32 val) {
 u32 Cs2TrackToFAD(u16 trackandindex) {
   if (trackandindex == 0xFFFF)
      // leadout position
-     return (Cs2Area->TOC[101] & 0x00FFFFFF); 
+     return (Cs2Area->TOC[101] & 0x00FFFFFF);
   if (trackandindex != 0x0000)
   {
      // regular track
@@ -2901,7 +2903,7 @@ partition_struct * Cs2FilterData(filter_struct * curfilter, int isaudio)
      {
         // Mode 2
         // go through various subheader filter conditions
-   
+
         if (curfilter->mode & 0x01)
         {
            // File Number Check
@@ -3132,7 +3134,7 @@ int Cs2ReadFileSystem(filter_struct * curfilter, u32 fid, int isoffset)
    u32 curdirlba = 0;
    partition_struct * rfspartition;
    u32 blocksectsize = Cs2Area->getsectsize;
- 
+
    Cs2Area->outconcddev = curfilter;
 
    if (isoffset)
@@ -3234,11 +3236,11 @@ int Cs2ReadFileSystem(filter_struct * curfilter, u32 fid, int isoffset)
                rfspartition->size -= rfspartition->block[rfspartition->numblocks - 1]->size;
                Cs2FreeBlock(rfspartition->block[rfspartition->numblocks - 1]);
                rfspartition->blocknum[rfspartition->numblocks - 1] = 0xFF;
-       
+
                // Sort remaining blocks
                Cs2SortBlocks(rfspartition);
                rfspartition->numblocks -= 1;
-   
+
                // Read in next sector of directory record
                if ((rfspartition = Cs2ReadUnFilteredSector(curdirlba+150)) == NULL)
                   return -2;
@@ -3272,11 +3274,11 @@ int Cs2ReadFileSystem(filter_struct * curfilter, u32 fid, int isoffset)
             rfspartition->size -= rfspartition->block[rfspartition->numblocks - 1]->size;
             Cs2FreeBlock(rfspartition->block[rfspartition->numblocks - 1]);
             rfspartition->blocknum[rfspartition->numblocks - 1] = 0xFF;
-       
+
             // Sort remaining blocks
             Cs2SortBlocks(rfspartition);
             rfspartition->numblocks -= 1;
-   
+
             // Read in next sector of directory record
             if ((rfspartition = Cs2ReadUnFilteredSector(curdirlba+150)) == NULL)
                return -2;
@@ -3426,7 +3428,7 @@ int Cs2ReadFilteredSector(u32 rfsFAD, partition_struct **partition) {
   int isaudio = 0;
 
   if (Cs2Area->outconcddev != NULL && !Cs2Area->isbufferfull)
-  {     
+  {
      // read a sector using cd interface function to workblock.data
      if (!Cs2Area->cdi->ReadSectorFAD(rfsFAD, Cs2Area->workblock.data))
      {
@@ -3464,7 +3466,7 @@ int Cs2ReadFilteredSector(u32 rfsFAD, partition_struct **partition) {
 
      // pass workblock to filter function(after it identifies partition,
      // it should allocate the partition block, setup/change the partition
-     // values, and copy workblock to the allocated block)        
+     // values, and copy workblock to the allocated block)
      *partition = Cs2FilterData(Cs2Area->outconcddev, isaudio);
      return 0;
   }
@@ -3526,7 +3528,7 @@ u8 Cs2GetIP(int autoregion) {
             cdip->msh2stack = 0x6002000;
          }
 
-         // for Panzer Dragoon Zwei. This operation is not written in the document. 
+         // for Panzer Dragoon Zwei. This operation is not written in the document.
          if (cdip->msh2stack & 0x80000000)
          {
             cdip->msh2stack = 0x06000000 + (cdip->msh2stack & 0x0000FFFF );


### PR DESCRIPTION
Applying [commit](https://github.com/Yabause/yabause/commit/4704eaca1cfe0b9380e8cce85ffeb1ae79775a0f) from Yabause. Fixes "no sound" in games like Sega Rally.

Change is at line [1530](https://github.com/libretro/yabause/compare/master...raelgc:master#diff-1cf6c2a0388f442cc0b87f43d775c614R1530).

Sorry for the blank space removal (my editor is configured to auto remove). I can undo if required.