### PR TITLE
VidSoft improvements, new Scsp

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,12 +28,15 @@ environment:
     # included directx headers incompatible with mingw
       cmake_args: "-DYAB_NETWORK=ON -DYAB_WANT_GDBSTUB=ON"
 
+    # MSYS2 x86_64 build
+    - compiler_type: "msys2-mingw-w64-x86_64"
+
 shallow_clone: true
 
 init:
   # cmake errors if sh on the path
-  - rm "C:\Program Files (x86)\Git\bin\sh.exe"
-  # - rm "C:\Program Files\Git\usr\bin\sh.exe"
+  # - rm "C:\Program Files (x86)\Git\bin\sh.exe"
+  - rm "C:\Program Files\Git\usr\bin\sh.exe"
   # cpack won't work because of chocolatey sharing the same name
   - rm "C:\ProgramData\chocolatey\bin\cpack.exe"
   - set Path=%MINGW%\bin;%Path%
@@ -41,10 +44,10 @@ init:
 before_build:
   # fetch appropriate sdl lib for visual studio or mingw
   - cd c:\
-  - appveyor DownloadFile https://www.libsdl.org/release/%sdl_filename%
+  - if NOT ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] appveyor DownloadFile https://www.libsdl.org/release/%sdl_filename%
 
   # decompress it, shorten 7z output with FIND
-  - 7z x %sdl_filename%  | FIND /V "ing  "
+  - if NOT ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] 7z x %sdl_filename%  | FIND /V "ing  "
 
   # mingw version is a tar.gz, decompress again
   - if [%sdl_filename%]==[SDL2-devel-2.0.3-mingw.tar.gz] 7z x SDL2-devel-2.0.3-mingw.tar | FIND /V "ing  "
@@ -53,10 +56,19 @@ before_build:
   - cd C:\projects\yabause\yabause
   - mkdir build
   - cd build
-  - cmake -G "%generator%" %cmake_args% -DSDL2MAIN_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2main.lib -DSDL2_INCLUDE_DIR=C:/SDL2-2.0.3/include/ -DSDL2_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2.lib ..
+  - if NOT ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] cmake -G "%generator%" %cmake_args% -DSDL2MAIN_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2main.lib -DSDL2_INCLUDE_DIR=C:/SDL2-2.0.3/include/ -DSDL2_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2.lib ..
+
+  #MSYS2
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] set MSYSTEM=MINGW64
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64;%PATH%
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-SDL2 mingw-w64-x86_64-binutils mingw64/mingw-w64-x86_64-qt5 mingw-w64-x86_64-crt-git mingw-w64-x86_64-headers-git mingw64/mingw-w64-x86_64-libwebp"
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "cd C:/projects/yabause/yabause/build ; cmake -G\"MSYS Makefiles\" -DDirectX_INCLUDE_DIR=C:/msys64/mingw64/x86_64-w64-mingw32/include -DYAB_WANT_DIRECTSOUND=OFF -DYAB_WANT_DIRECTINPUT=OFF -DYAB_NETWORK=ON -DYAB_WANT_GDBSTUB=ON -DMSYS2_BUILD=ON -DCMAKE_PREFIX_PATH=C:/msys64/mingw64/bin -DSDL2MAIN_LIBRARY=C:/msys64/mingw64/lib/libSDL2main.a .."
 
 build_script:
   - if ["%compiler_type%"]==["mingw32"] cmake --build .
+
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "cd C:/projects/yabause/yabause/build ; make "
 
   # force a release build and only show errors to shorten output
   - if ["%compiler_type%"]==["vs12-x64"] msbuild yabause.sln /p:configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -57,9 +57,9 @@ endif
 
 ifeq ($(HAVE_GL),1)
 SOURCES_C += \
-	$(SOURCE_DIR)/ygl.c \
+	$(SOURCE_DIR)/ygles.c \
 	$(SOURCE_DIR)/vidogl.c \
-	$(SOURCE_DIR)/yglshader.c
+	$(SOURCE_DIR)/yglshaderes.c
 endif
 
 ifneq ($(HAVE_GRIFFIN), 1)

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -16,6 +16,7 @@ SOURCES_C := $(SOURCE_DIR)/osdcore.c \
 	$(SOURCE_DIR)/cs2.c \
 	$(SOURCE_DIR)/debug.c \
 	$(SOURCE_DIR)/error.c \
+	$(SOURCE_DIR)/gameinfo.c \
 	$(SOURCE_DIR)/japmodem.c \
 	$(SOURCE_DIR)/m68kc68k.c \
 	$(SOURCE_DIR)/m68kcore.c \

--- a/yabause/src/CMakeLists.txt
+++ b/yabause/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(yabause_HEADERS
 	cdbase.h cheat.h coffelf.h core.h cs0.h cs1.h cs2.h
 	debug.h
 	error.h
+	gameinfo.h
 	japmodem.h
 	m68kcore.h m68kd.h memory.h movie.h
 	netlink.h
@@ -28,6 +29,7 @@ set(yabause_SOURCES
 	cdbase.c cheat.c coffelf.c cs0.c cs1.c cs2.c
 	debug.c
 	error.c
+	gameinfo.c
 	japmodem.c
 	m68kcore.c m68kd.c memory.c movie.c
 	netlink.c

--- a/yabause/src/android/CMakeLists.txt
+++ b/yabause/src/android/CMakeLists.txt
@@ -27,6 +27,8 @@ if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
 		jni/sndopensl.c
 		jni/sndopensl.h
 		src/org/yabause/android/Cartridge.java
+		src/org/yabause/android/GameInfo.java
+		src/org/yabause/android/GameInfoManager.java
 		src/org/yabause/android/GameList.java
 		src/org/yabause/android/GameListAdapter.java
 		src/org/yabause/android/Home.java
@@ -123,6 +125,8 @@ set(yabause_android_RES
 )
 set(yabause_android_SRC
     "${CMAKE_CURRENT_BINARY_DIR}/src/org/yabause/android/Cartridge.java"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/org/yabause/android/GameInfo.java"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/org/yabause/android/GameInfoManager.java"
     "${CMAKE_CURRENT_BINARY_DIR}/src/org/yabause/android/GameList.java"
     "${CMAKE_CURRENT_BINARY_DIR}/src/org/yabause/android/GameListAdapter.java"
     "${CMAKE_CURRENT_BINARY_DIR}/src/org/yabause/android/Home.java"

--- a/yabause/src/android/jni/yui.c
+++ b/yabause/src/android/jni/yui.c
@@ -33,6 +33,7 @@
 #include "cs2.h"
 #include "debug.h"
 #include "osdcore.h"
+#include "gameinfo.h"
 
 #include <stdio.h>
 #include <dlfcn.h>
@@ -565,6 +566,36 @@ Java_org_yabause_android_YabauseRunnable_screenshot( JNIEnv* env, jobject obj, j
     }
 
     AndroidBitmap_unlockPixels(env, bitmap);
+}
+
+jobject Java_org_yabause_android_YabauseRunnable_gameInfo( JNIEnv* env, jobject obj, jobject path )
+{
+    jmethodID cons;
+    jboolean dummy;
+    jclass c;
+    jstring system, company, itemnum, version, date, cdinfo, region, peripheral, gamename;
+    GameInfo info;
+    const char * filename = (*env)->GetStringUTFChars(env, path, &dummy);
+
+    if (! GameInfoFromPath(filename, &info))
+    {
+       return NULL;
+    }
+
+    c = (*env)->FindClass(env, "org/yabause/android/GameInfo");
+    cons = (*env)->GetMethodID(env, c, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+
+    system = (*env)->NewStringUTF(env, info.system);
+    company = (*env)->NewStringUTF(env, info.company);
+    itemnum = (*env)->NewStringUTF(env, info.itemnum);
+    version = (*env)->NewStringUTF(env, info.version);
+    date = (*env)->NewStringUTF(env, info.date);
+    cdinfo = (*env)->NewStringUTF(env, info.cdinfo);
+    region = (*env)->NewStringUTF(env, info.region);
+    peripheral = (*env)->NewStringUTF(env, info.peripheral);
+    gamename = (*env)->NewStringUTF(env, info.gamename);
+
+    return (*env)->NewObject(env, c, cons, system, company, itemnum, version, date, cdinfo, region, peripheral, gamename);
 }
 
 void log_callback(char * message)

--- a/yabause/src/android/res/layout/game_item.xml
+++ b/yabause/src/android/res/layout/game_item.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceLarge"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:gravity="center_vertical"
-    android:paddingLeft="6dip"
-    android:minHeight="?android:attr/listPreferredItemHeight" />
+    android:orientation="vertical" >
+
+    <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/game_name"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:gravity="center_vertical"
+        android:paddingLeft="6dip" />
+
+</LinearLayout>

--- a/yabause/src/android/src/org/yabause/android/GameInfo.java
+++ b/yabause/src/android/src/org/yabause/android/GameInfo.java
@@ -1,0 +1,113 @@
+/*  Copyright 2016 Guillaume Duhamel
+
+    This file is part of Yabause.
+
+    Yabause is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Yabause is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Yabause; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+package org.yabause.android;
+
+import java.text.SimpleDateFormat;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Locale;
+
+class GameInfo
+{
+    private String system;
+    private String company;
+    private String itemnum;
+    private String version;
+    private String date;
+    private String cdinfo;
+    private String region;
+    private String peripheral;
+    private String gamename;
+
+    public GameInfo(String system, String company, String itemnum, String version, String date, String cdinfo, String region, String peripheral, String gamename)
+    {
+        this.system = system;
+        this.company = company;
+        this.itemnum = itemnum;
+        this.version = version;
+        this.date = date;
+        this.cdinfo = cdinfo;
+        this.region = region;
+        this.peripheral = peripheral;
+        this.gamename = gamename;
+    }
+
+    public String getSystem()
+    {
+        return this.system;
+    }
+
+    public String getCompany()
+    {
+        return this.company;
+    }
+
+    public String getItemnum()
+    {
+        return this.itemnum;
+    }
+
+    public String getVersion()
+    {
+        return this.version;
+    }
+
+    public String getDate()
+    {
+        return this.date;
+    }
+
+    public String getCdinfo()
+    {
+        return this.cdinfo;
+    }
+
+    public String getRegion()
+    {
+        return this.region;
+    }
+
+    public String getPeripheral()
+    {
+        return this.peripheral;
+    }
+
+    public String getGamename()
+    {
+        return this.gamename;
+    }
+
+    public String getName()
+    {
+        return this.gamename.replaceAll("\\s+", " ");
+    }
+
+    public String getHumanDate() {
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy", Locale.US);
+            DateFormat df = DateFormat.getDateInstance();
+            Date date = sdf.parse(this.date);
+            return df.format(date);
+        } catch(ParseException exc) {
+            return this.date;
+        }
+    }
+}

--- a/yabause/src/android/src/org/yabause/android/GameInfoManager.java
+++ b/yabause/src/android/src/org/yabause/android/GameInfoManager.java
@@ -1,0 +1,111 @@
+/*  Copyright 2016 Guillaume Duhamel
+
+    This file is part of Yabause.
+
+    Yabause is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Yabause is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Yabause; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+package org.yabause.android;
+
+import org.yabause.android.GameInfo;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import java.util.HashMap;
+
+class GameInfoOpenHelper extends SQLiteOpenHelper {
+    private static final int DATABASE_VERSION = 1;
+    private static final String GAMEINFO_TABLE_NAME = "gameinfo";
+    private static final String GAMEINFO_TABLE_CREATE =
+                "CREATE TABLE " + GAMEINFO_TABLE_NAME + " (" +
+                 "path TEXT PRIMARY KEY, " +
+                 "system TEXT, " +
+                 "company TEXT, " +
+                 "itemnum TEXT, " +
+                 "version TEXT, " +
+                 "date TEXT, " +
+                 "cdinfo TEXT, " +
+                 "region TEXT, " +
+                 "peripheral TEXT, " +
+                 "gamename TEXT);";
+
+    GameInfoOpenHelper(Context context) {
+        super(context, "gameinfo", null, DATABASE_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL(GAMEINFO_TABLE_CREATE);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    }
+}
+
+class GameInfoManager
+{
+    private GameInfoOpenHelper opener;
+    private HashMap<String, GameInfo> games;
+
+    public GameInfoManager(Context ctx)
+    {
+        this.opener = new GameInfoOpenHelper(ctx);
+        this.games = new HashMap<String, GameInfo>();
+
+        SQLiteDatabase db = this.opener.getReadableDatabase();
+        Cursor cur = db.rawQuery("SELECT path, system, company, itemnum, version, date, cdinfo, region, peripheral, gamename FROM gameinfo", null);
+        while(cur.moveToNext())
+        {
+            String path = cur.getString(0);
+            GameInfo gi = new GameInfo(cur.getString(1), cur.getString(2), cur.getString(3),
+                cur.getString(4), cur.getString(5), cur.getString(6),
+                cur.getString(7), cur.getString(8), cur.getString(9));
+            games.put(path, gi);
+        }
+        cur.close();
+    }
+
+    public GameInfo gameInfo(String name) {
+        String path = YabauseStorage.getStorage().getGamePath(name);
+
+        GameInfo gi = games.get(path);
+
+        if (gi == null) {
+            gi = YabauseRunnable.gameInfo(path);
+            if (gi != null) {
+                SQLiteDatabase db = this.opener.getWritableDatabase();
+                ContentValues cv = new ContentValues();
+                cv.put("path", path);
+                cv.put("system", gi.getSystem());
+                cv.put("company", gi.getCompany());
+                cv.put("itemnum", gi.getItemnum());
+                cv.put("version", gi.getVersion());
+                cv.put("date", gi.getDate());
+                cv.put("cdinfo", gi.getCdinfo());
+                cv.put("region", gi.getRegion());
+                cv.put("peripheral", gi.getPeripheral());
+                cv.put("gamename", gi.getGamename());
+                db.insert("gameinfo", null, cv);
+
+                games.put(path, gi);
+            }
+        }
+
+        return gi;
+    }
+}

--- a/yabause/src/android/src/org/yabause/android/GameListAdapter.java
+++ b/yabause/src/android/src/org/yabause/android/GameListAdapter.java
@@ -27,16 +27,19 @@ import android.view.ViewGroup;
 import android.widget.ListAdapter;
 import android.widget.TextView;
 import org.yabause.android.YabauseStorage;
+import org.yabause.android.GameInfoManager;
 
 class GameListAdapter implements ListAdapter {
     private YabauseStorage storage;
     private String[] gamefiles;
     private Context context;
+    private GameInfoManager gim;
 
     GameListAdapter(Context ctx) {
         storage = YabauseStorage.getStorage();
         gamefiles = storage.getGameFiles();
         context = ctx;
+        gim = new GameInfoManager(ctx);
     }
 
     public int getCount() {
@@ -56,16 +59,26 @@ class GameListAdapter implements ListAdapter {
     }
 
     public View getView(int position, View convertView, ViewGroup parent) {
-        TextView tv;
+        View layout;
+        TextView name;
 
         if (convertView != null) {
-            tv = (TextView) convertView;
+            layout = convertView;
         } else {
             LayoutInflater inflater = (LayoutInflater) context.getSystemService( Context.LAYOUT_INFLATER_SERVICE );
-            tv = (TextView) inflater.inflate(R.layout.game_item, parent, false);
+            layout = inflater.inflate(R.layout.game_item, parent, false);
         }
-        tv.setText(gamefiles[position]);
-        return tv;
+
+        name = (TextView) layout.findViewById(R.id.game_name);
+
+        GameInfo gi = gim.gameInfo(gamefiles[position]);
+        if (gi == null) {
+            name.setText(gamefiles[position]);
+        } else {
+            name.setText(gi.getName());
+        }
+
+        return layout;
     }
 
     public int getViewTypeCount() {

--- a/yabause/src/android/src/org/yabause/android/Home.java
+++ b/yabause/src/android/src/org/yabause/android/Home.java
@@ -49,4 +49,8 @@ public class Home extends Activity
         Intent intent = new Intent(this, YabauseSettings.class);
         startActivity(intent);
     }
+
+    static {
+        System.loadLibrary("yabause");
+    }
 }

--- a/yabause/src/android/src/org/yabause/android/Yabause.java
+++ b/yabause/src/android/src/org/yabause/android/Yabause.java
@@ -45,6 +45,7 @@ import android.graphics.Bitmap;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.net.Uri;
+import org.yabause.android.GameInfo;
 
 class InputHandler extends Handler {
     private YabauseRunnable yr;
@@ -79,6 +80,7 @@ class YabauseRunnable implements Runnable
     public static native void enableFrameskip(int enable);
     public static native void setVolume(int volume);
     public static native void screenshot(Bitmap bitmap);
+    public static native GameInfo gameInfo(String path);
 
     private boolean inited;
     private boolean paused;
@@ -342,9 +344,5 @@ public class Yabause extends Activity implements OnPadListener
 
     public String getCartridgePath() {
         return YabauseStorage.getStorage().getCartridgePath(Cartridge.getDefaultFilename(carttype));
-    }
-
-    static {
-        System.loadLibrary("yabause");
     }
 }

--- a/yabause/src/gameinfo.c
+++ b/yabause/src/gameinfo.c
@@ -1,0 +1,43 @@
+/*  Copyright 2016 Guillaume Duhamel
+
+    This file is part of Yabause.
+
+    Yabause is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Yabause is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Yabause; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#include <dirent.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "gameinfo.h"
+#include "cdbase.h"
+#include "cs2.h"
+
+extern ip_struct * cdip;
+
+int GameInfoFromPath(const char * filename, GameInfo * info)
+{
+   if (cdip != NULL) return 0;
+
+   Cs2Init(0, CDCORE_ISO, filename, NULL, NULL, NULL);
+   Cs2GetIP(1);
+
+   memcpy(info, cdip, sizeof(GameInfo));
+
+   Cs2DeInit();
+
+   return 1;
+}

--- a/yabause/src/gameinfo.c
+++ b/yabause/src/gameinfo.c
@@ -17,10 +17,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
-#include <dirent.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 
 #include "gameinfo.h"
 #include "cdbase.h"

--- a/yabause/src/gameinfo.h
+++ b/yabause/src/gameinfo.h
@@ -1,0 +1,42 @@
+/*  Copyright 2016 Guillaume Duhamel
+
+    This file is part of Yabause.
+
+    Yabause is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Yabause is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Yabause; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef GAMESINFO_H
+#define GAMESINFO_H
+
+typedef struct _GameInfo GameInfo;
+struct _GameInfo
+{
+   char system[17];
+   char company[17];
+   char itemnum[11];
+   char version[7];
+   char date[11];
+   char cdinfo[9];
+   char region[11];
+   char peripheral[17];
+   char gamename[113];
+};
+
+/* Copy part of cdip information info GameInfo. This function
+   only works if the emulator is not running, ie: not between
+   YabauseInit and YabauseDeInit. */
+int GameInfoFromPath(const char * filename, GameInfo * info);
+
+#endif

--- a/yabause/src/peripheral.c
+++ b/yabause/src/peripheral.c
@@ -392,7 +392,7 @@ void PerMouseMove(PerMouse_struct * mouse, s32 dispx, s32 dispy)
    if (negy) diffy = ~(mouse->mousebits[2]) & 0xFF;
    else diffy = mouse->mousebits[2];
 
-   if (dispx > 0)
+   if (dispx >= 0)
    {
       if (negx)
       {
@@ -419,7 +419,7 @@ void PerMouseMove(PerMouse_struct * mouse, s32 dispx, s32 dispy)
       }
    }
 
-   if (dispy > 0)
+   if (dispy >= 0)
    {
       if (negy)
       {
@@ -934,7 +934,7 @@ int PERDummyHandleEvents(void) {
 
 u32 PERDummyScan(u32 flags) {
    // Scan and return next action based on flags value
-   // See PERSF_* in peripheral.h for full list of flags. 
+   // See PERSF_* in peripheral.h for full list of flags.
    // If no specified flags are supported return 0
 
    return 0;

--- a/yabause/src/qt/CMakeLists.txt
+++ b/yabause/src/qt/CMakeLists.txt
@@ -4,11 +4,11 @@ yab_port_start()
 
 option(YAB_USE_QT5 "Use Qt 5 if available." ON)
 
-if(YAB_USE_QT5) 
+if(YAB_USE_QT5)
 	find_package(Qt5 COMPONENTS Widgets QUIET)
 endif()
 
-if(Qt5_FOUND) 
+if(Qt5_FOUND)
 	message(STATUS "Qt5 Found")
 
 	if( YAB_WANT_OPENGL )
@@ -16,7 +16,7 @@ if(Qt5_FOUND)
 	endif()
 
 	include_directories(${Qt5Widgets_INCLUDE_DIRS})
-	add_definitions(${Qt5Widgets_DEFINITIONS}) 
+	add_definitions(${Qt5Widgets_DEFINITIONS})
 
 	if (WIN32)
         	find_package(Qt5Core)
@@ -27,7 +27,7 @@ if(Qt5_FOUND)
     # Since Qt5's cmake script doesn't set it, we will have to
     SET(QT_BINARY_DIR "${_qt5Core_install_prefix}/bin")
     SET(QT_PLUGINS_DIR "${_qt5Core_install_prefix}/plugins")
-else() 
+else()
 	set( QT_USE_QTCORE TRUE )
 	set( QT_USE_QTGUI TRUE )
 	set ( QT_USE_QTMULTIMEDIA TRUE )
@@ -37,7 +37,7 @@ else()
 	if (WIN32)
 		set( QT_USE_QTMAIN TRUE )
 	endif()
-	
+
 	find_package(Qt4)
 
 	if (NOT QT4_FOUND)
@@ -53,7 +53,7 @@ else()
 
 	# dunno what it does exactly ... but seem required
 	include( ${QT_USE_FILE} )
-endif() 
+endif()
 
 # qt resources file
 set( yabause_qt_RESOURCES resources/resources.qrc )
@@ -84,10 +84,10 @@ set( yabause_qt_FORMS
 	ui/UICheatSearch.ui
 	ui/UIBackupRam.ui
 	ui/UIPortManager.ui
-	ui/UIPadSetting.ui 
-	ui/UI3DControlPadSetting.ui 
+	ui/UIPadSetting.ui
+	ui/UI3DControlPadSetting.ui
 	ui/UIGunSetting.ui
-	ui/UIMouseSetting.ui 
+	ui/UIMouseSetting.ui
     ui/UIDebugCPU.ui
     ui/UIDebugSCSP.ui
     ui/UIDebugSCSPDSP.ui
@@ -95,8 +95,8 @@ set( yabause_qt_FORMS
     ui/UIDebugVDP2.ui
     ui/UIDebugVDP2Viewer.ui
     ui/UIHexInput.ui
-    ui/UIMemoryTransfer.ui 
-    ui/UIMemoryEditor.ui 
+    ui/UIMemoryTransfer.ui
+    ui/UIMemoryEditor.ui
     ui/UIMemorySearch.ui )
 
 # pure C headers
@@ -190,15 +190,15 @@ else()
 	set( yabause_qt_SOURCES ${yabause_qt_SOURCES} YabauseSoftGL.cpp )
 endif()
 
-if(Qt5_FOUND) 
+if(Qt5_FOUND)
 	QT5_ADD_RESOURCES( yabause_qt_RCC_RESOURCES ${yabause_qt_RESOURCES} )
 	QT5_WRAP_UI( yabause_qt_UI_FORMS ${yabause_qt_FORMS} )
 	QT5_WRAP_CPP( yabause_qt_MOC_SOURCES ${yabause_qt_MOC_HEADERS} )
-else() 
+else()
 	QT4_ADD_RESOURCES( yabause_qt_RCC_RESOURCES ${yabause_qt_RESOURCES} )
 	QT4_WRAP_UI( yabause_qt_UI_FORMS ${yabause_qt_FORMS} )
 	QT4_WRAP_CPP( yabause_qt_MOC_SOURCES ${yabause_qt_MOC_HEADERS} )
-endif() 
+endif()
 
 set( yabause_qt_SOURCES ${yabause_qt_SOURCES} resources/icons/yabause.icns )
 set_source_files_properties( resources/icons/yabause.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
@@ -219,7 +219,7 @@ include_directories(
 	${CMAKE_CURRENT_BINARY_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}/ui
 	${Qt5Widgets_INCLUDE_DIRS}
-	${Qt5OpenGL_INCLUDE_DIRS} 
+	${Qt5OpenGL_INCLUDE_DIRS}
 	${Qt5Multimedia_INCLUDE_DIRS} )
 else()
 include_directories(
@@ -256,7 +256,7 @@ endif()
 yab_port_success(yabause-qt)
 configure_file(yabause.desktop.in ${YAB_PORT_NAME}.desktop)
 
-if (WIN32)
+if (WIN32 AND NOT MSYS2_BUILD)
 	install(TARGETS yabause-qt DESTINATION ".")
 	if (GLUT_FOUND)
 		install(FILES ${GLUT_INCLUDE_DIR}/../freeglut.dll DESTINATION ".")
@@ -273,7 +273,7 @@ if (WIN32)
 			DESTINATION "."
 			FILES_MATCHING PATTERN "SDL2.dll")
 	endif ()
-	if(Qt5_FOUND) 
+	if(Qt5_FOUND)
 		install(FILES ${QT_BINARY_DIR}/Qt5Core.dll DESTINATION ".")
 		install(FILES ${QT_BINARY_DIR}/Qt5Gui.dll DESTINATION ".")
 		install(FILES ${QT_BINARY_DIR}/Qt5OpenGL.dll DESTINATION ".")
@@ -289,7 +289,7 @@ if (WIN32)
 		install(FILES ${QT_BINARY_DIR}/QtGui4.dll DESTINATION ".")
 		install(FILES ${QT_BINARY_DIR}/QtOpenGL4.dll DESTINATION ".")
 		if (QT_QTMULTIMEDIA_FOUND)
-			install(FILES ${QT_BINARY_DIR}/QtMultimedia4.dll DESTINATION ".")        
+			install(FILES ${QT_BINARY_DIR}/QtMultimedia4.dll DESTINATION ".")
 		endif()
 	endif()
 
@@ -298,7 +298,7 @@ if (WIN32)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../COPYING    DESTINATION "." RENAME COPYING.txt)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../README     DESTINATION "." RENAME README.txt)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../README.WIN DESTINATION "." RENAME README.WIN.txt)
-	
+
 	if (MINGW)
 		get_filename_component( Mingw_Path ${CMAKE_CXX_COMPILER} PATH )
 		if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")

--- a/yabause/src/scsp.c
+++ b/yabause/src/scsp.c
@@ -117,7 +117,6 @@
 # define FLUSH_SCSP()  /*nothing*/
 #endif
 
-#ifdef USE_NEW_SCSP
 enum EnvelopeStates
 {
    ATTACK,
@@ -173,17 +172,19 @@ const u8 decay_rate_table[][4] =
    { 8,8,8,8 },//0x3f
 };
 
+#define EFFECTIVE_RATE_END 0xffff
+
 //effective rate step table
 //settings 0x2 to 0x5, then repeats with bigger shifts
-//int_max represents going back to the beginning of a row since
+//EFFECTIVE_RATE_END represents going back to the beginning of a row since
 //the number of steps is not the same for each setting
 #define MAKE_TABLE(SHIFT) \
-   { 8192 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, INT_MAX,INT_MAX,INT_MAX,INT_MAX, INT_MAX }, \
-   { 8192 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, INT_MAX }, \
-   { 4096 >> SHIFT, INT_MAX,INT_MAX,INT_MAX,INT_MAX, INT_MAX,INT_MAX , INT_MAX }, \
-   { 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 2048 >> SHIFT, 2048 >> SHIFT, INT_MAX, INT_MAX, INT_MAX },
+   { 8192 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, EFFECTIVE_RATE_END,EFFECTIVE_RATE_END,EFFECTIVE_RATE_END,EFFECTIVE_RATE_END, EFFECTIVE_RATE_END }, \
+   { 8192 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, EFFECTIVE_RATE_END }, \
+   { 4096 >> SHIFT, EFFECTIVE_RATE_END,EFFECTIVE_RATE_END,EFFECTIVE_RATE_END,EFFECTIVE_RATE_END, EFFECTIVE_RATE_END,EFFECTIVE_RATE_END , EFFECTIVE_RATE_END }, \
+   { 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 2048 >> SHIFT, 2048 >> SHIFT, EFFECTIVE_RATE_END, EFFECTIVE_RATE_END, EFFECTIVE_RATE_END },
 
-const int envelope_table[][8] =
+const u16 envelope_table[][8] =
 {
    MAKE_TABLE(0)
    MAKE_TABLE(1)
@@ -278,6 +279,8 @@ struct Scsp
 {
    u16 sound_stack[64];
    struct Slot slots[32];
+
+   int debug_mode;
 }new_scsp;
 
 //pg, plfo
@@ -451,7 +454,7 @@ int need_envelope_step(int effective_rate, u32 sample_counter, struct Slot* slot
          slot->state.envelope_steps_taken++;
          slot->state.step_count++;
 
-         if (envelope_table[pos][slot->state.step_count] == INT_MAX)
+         if (envelope_table[pos][slot->state.step_count] == EFFECTIVE_RATE_END)
             slot->state.step_count = 0;//reached the end of the array
       }
 
@@ -594,6 +597,99 @@ void op7(struct Slot * slot, struct Scsp*s)
    slot->state.sample_counter++;
 }
 
+struct DebugInstrument
+{
+   u32 sa;
+   int is_muted;
+};
+
+#define NUM_DEBUG_INSTRUMENTS 24
+
+struct DebugInstrument debug_instruments[NUM_DEBUG_INSTRUMENTS] = { 0 };
+int debug_instrument_pos = 0;
+
+void scsp_debug_search_instruments(const u32 sa, int* found, int * offset)
+{
+   int i = 0;
+   *found = 0;
+   for (i = 0; i < NUM_DEBUG_INSTRUMENTS; i++)
+   {
+      if (debug_instruments[i].sa == sa)
+      {
+         *found = 1;
+         break;
+      }
+   }
+
+   *offset = i;
+}
+
+void scsp_debug_add_instrument(u32 sa)
+{
+   int i = 0, found = 0, offset = 0;
+
+   if (debug_instrument_pos >= NUM_DEBUG_INSTRUMENTS)
+      return;
+
+   scsp_debug_search_instruments(sa, &found, &offset);
+
+   //new instrument discovered
+   if (!found)
+      debug_instruments[debug_instrument_pos++].sa = sa;
+}
+
+void scsp_debug_instrument_set_mute(u32 sa, int mute)
+{
+   int found = 0, offset = 0;
+   scsp_debug_search_instruments(sa, &found, &offset);
+
+   if (offset >= NUM_DEBUG_INSTRUMENTS)
+      return;
+
+   if (found)
+      debug_instruments[offset].is_muted = mute;
+}
+
+int scsp_debug_instrument_check_is_muted(u32 sa)
+{
+   int found = 0, offset = 0;
+   scsp_debug_search_instruments(sa, &found, &offset);
+
+   if (offset >= NUM_DEBUG_INSTRUMENTS)
+      return 0;
+
+   if (found && debug_instruments[offset].is_muted)
+      return 1;
+
+   return 0;
+}
+
+void scsp_debug_instrument_get_data(int i, u32 * sa, int * is_muted)
+{
+   if(i >= NUM_DEBUG_INSTRUMENTS)
+      return;
+
+   *sa = debug_instruments[i].sa;
+   *is_muted = debug_instruments[i].is_muted;
+}
+
+void scsp_debug_set_mode(int mode)
+{
+   new_scsp.debug_mode = mode;
+}
+
+void scsp_debug_instrument_clear()
+{
+   debug_instrument_pos = 0;
+   memset(debug_instruments, 0, sizeof(struct DebugInstrument) * NUM_DEBUG_INSTRUMENTS);
+}
+
+void scsp_debug_get_envelope(int chan, int * env, int * state)
+{
+   *env = new_scsp.slots[chan].state.attenuation;
+   *state = new_scsp.slots[chan].state.envelope;
+}
+
 void keyon(struct Slot * slot)
 {
    if (slot->state.envelope == RELEASE)
@@ -604,6 +700,9 @@ void keyon(struct Slot * slot)
       slot->state.step_count = 0;
       slot->state.sample_offset = 0;
       slot->state.envelope_steps_taken = 0;
+
+      if (new_scsp.debug_mode)
+         scsp_debug_add_instrument(slot->regs.sa);
    }
    //otherwise ignore
 }
@@ -698,7 +797,7 @@ void scsp_slot_write_byte(struct Scsp *s, u32 addr, u8 data)
       slot->regs.mdxsl = (slot->regs.mdxsl & 0x3) | ((data & 0xf) << 2);
       break;
    case 15:
-      slot->regs.mdxsl = (slot->regs.mdxsl & 0x3C) | (data >> 6) & 3;
+      slot->regs.mdxsl = (slot->regs.mdxsl & 0x3C) | ((data >> 6) & 3);
       slot->regs.mdysl = data & 0x3f;
       break;
    case 16:
@@ -1036,35 +1135,21 @@ int get_sdl_shift(int sdl)
 {
    if (sdl == 0)
       return 16;//-infinity
-   else return (7 - sdl) * 2;
+   else return (7 - sdl);
 }
 
 void generate_sample(struct Scsp * s, int rbp, int rbl, s16 * out_l, s16* out_r, int mvol, s16 cd_in_l, s16 cd_in_r)
 {
-   static int inited = 0;
    int step_num = 0;
    int i = 0;
-
-   if (!inited)
-   {
-      int slot_num;
-      memset(&new_scsp, 0, sizeof(struct Scsp));
-
-      for (slot_num = 0; slot_num < 32; slot_num++)
-      {
-         s->slots[slot_num].state.attenuation = 0x3FF;
-         s->slots[slot_num].state.envelope = RELEASE;
-         s->slots[slot_num].state.num = slot_num;
-      }
-
-      inited = 1;
-   }
+   int mvol_shift = 0;
 
    //run 32 steps to generate 1 full sample (512 clock cycles at 22579200hz)
    //7 operations happen simultaneously on different channels due to pipelining
    for (step_num = 0; step_num < 32; step_num++)
    {
       int last_step = (step_num - 6) & 0x1f;
+      int debug_muted = 0;
 
       op1(&s->slots[step_num]);//phase, pitch lfo
       op2(&s->slots[(step_num - 1) & 0x1f],s);//address pointer, modulation data read
@@ -1074,8 +1159,13 @@ void generate_sample(struct Scsp * s, int rbp, int rbl, s16 * out_l, s16* out_r,
       op6(&s->slots[(step_num - 5) & 0x1f]);//level calc 2
       op7(&s->slots[(step_num - 6) & 0x1f],s);//sound stack write
 
+      if (new_scsp.debug_mode)
+      {
+         if (scsp_debug_instrument_check_is_muted(s->slots[last_step].regs.sa))
+            debug_muted = 1;
+      }
 
-      if (!s->slots[last_step].state.is_muted)
+      if (!debug_muted)
       {
          int disdl = get_sdl_shift(s->slots[last_step].regs.disdl);
 
@@ -1115,29 +1205,48 @@ void generate_sample(struct Scsp * s, int rbp, int rbl, s16 * out_l, s16* out_r,
 
       s16 efsdl_applied = (scsp_dsp.efreg[i] >> efsdl);
 
+      int pan_val_l = 0, pan_val_r = 0;
+      s16 panned_l = 0, panned_r = 0;
+
       if (i == 16)
          efsdl_applied = scsp_dsp.exts[0] >> efsdl;
 
       if (i == 17)
          efsdl_applied = scsp_dsp.exts[1] >> efsdl;
 
-      int pan_val_l = 0, pan_val_r = 0;
+
       get_panning(s->slots[i].regs.efpan, &pan_val_l, &pan_val_r);
 
-      s16 panned_l = (efsdl_applied >> pan_val_l) >> 2;
-      s16 panned_r = (efsdl_applied >> pan_val_r) >> 2;
+      panned_l = (efsdl_applied >> pan_val_l) >> 2;
+      panned_r = (efsdl_applied >> pan_val_r) >> 2;
 
       *out_l = *out_l + panned_l;
       *out_r = *out_r + panned_r;
    }
 
-   int mvol_shift = 0xf - mvol;
+   mvol_shift = 0xf - mvol;
 
    *out_l = *out_l >> mvol_shift;
    *out_r = *out_r >> mvol_shift;
 }
-#endif
 
+void new_scsp_reset(struct Scsp* s)
+{
+   int slot_num;
+   memset(s, 0, sizeof(struct Scsp));
+
+   for (slot_num = 0; slot_num < 32; slot_num++)
+   {
+      s->slots[slot_num].state.attenuation = 0x3FF;
+      s->slots[slot_num].state.envelope = RELEASE;
+      s->slots[slot_num].state.num = slot_num;
+   }
+
+   memset(&scsp_dsp, 0, sizeof(ScspDsp));
+
+   if(SoundRam)
+      memset(SoundRam, 0, 0x80000);
+}
 ////////////////////////////////////////////////////////////////
 
 #ifndef PI
@@ -4009,6 +4118,9 @@ scsp_reset (void)
 		slot->lfofmw = scsp_lfo_sawt_f;
 		slot->lfoemw = scsp_lfo_sawt_e;
     }
+#ifdef USE_NEW_SCSP
+  new_scsp_reset(&new_scsp);
+#endif
 }
 
 void

--- a/yabause/src/scsp.c
+++ b/yabause/src/scsp.c
@@ -596,7 +596,7 @@ void op7(struct Slot * slot, struct Scsp*s)
 
 void keyon(struct Slot * slot)
 {
-   if (slot->state.envelope == RELEASE || slot->state.attenuation > 0x3BF)
+   if (slot->state.envelope == RELEASE)
    {
       slot->state.envelope = ATTACK;
       slot->state.attenuation = 0x280;
@@ -1017,10 +1017,31 @@ u16 scsp_slot_read_word(struct Scsp *s, u32 addr)
    return data;
 }
 
-s16 generate_sample(struct Scsp * s, int rbp, int rbl)
+void get_panning(int pan, int * pan_val_l, int * pan_val_r)
+{
+   if (pan & 0x10)
+   {
+      //negative values
+      *pan_val_l = 0;
+      *pan_val_r = pan & 0xf;
+   }
+   else
+   {
+      *pan_val_l = pan & 0xf;
+      *pan_val_r = 0;
+   }
+}
+
+int get_sdl_shift(int sdl)
+{
+   if (sdl == 0)
+      return 16;//-infinity
+   else return (7 - sdl) * 2;
+}
+
+void generate_sample(struct Scsp * s, int rbp, int rbl, s16 * out_l, s16* out_r, int mvol, s16 cd_in_l, s16 cd_in_r)
 {
    static int inited = 0;
-   s16 output = 0;
    int step_num = 0;
    int i = 0;
 
@@ -1043,6 +1064,8 @@ s16 generate_sample(struct Scsp * s, int rbp, int rbl)
    //7 operations happen simultaneously on different channels due to pipelining
    for (step_num = 0; step_num < 32; step_num++)
    {
+      int last_step = (step_num - 6) & 0x1f;
+
       op1(&s->slots[step_num]);//phase, pitch lfo
       op2(&s->slots[(step_num - 1) & 0x1f],s);//address pointer, modulation data read
       op3(&s->slots[(step_num - 2) & 0x1f]);//waveform dram read
@@ -1051,20 +1074,32 @@ s16 generate_sample(struct Scsp * s, int rbp, int rbl)
       op6(&s->slots[(step_num - 5) & 0x1f]);//level calc 2
       op7(&s->slots[(step_num - 6) & 0x1f],s);//sound stack write
 
-      if (!s->slots[(step_num - 6) & 0x1f].state.is_muted)
+
+      if (!s->slots[last_step].state.is_muted)
       {
-         int isel = s->slots[(step_num - 6) & 0x1f].regs.isel;
-         s16 slot_out = s->slots[(step_num - 6) & 0x1f].state.output;
+         int disdl = get_sdl_shift(s->slots[last_step].regs.disdl);
 
-         if(s->slots[(step_num - 6) & 0x1f].regs.disdl)
-            output += slot_out >> 2;
+         s16 disdl_applied = (s->slots[last_step].state.output >> disdl);
 
-         scsp_dsp.mixs[isel] += slot_out << 4;
+         s16 mixs_input = s->slots[last_step].state.output >>
+            get_sdl_shift(s->slots[last_step].regs.imxl);
+
+         int pan_val_l = 0, pan_val_r = 0;
+
+         get_panning(s->slots[last_step].regs.dipan, &pan_val_l, &pan_val_r);
+
+         *out_l = *out_l + ((disdl_applied >> pan_val_l) >> 2);
+         *out_r = *out_r + ((disdl_applied >> pan_val_r) >> 2);
+
+         scsp_dsp.mixs[s->slots[last_step].regs.isel] += mixs_input << 4;
       }
    }
 
    scsp_dsp.rbp = rbp;
    scsp_dsp.rbl = rbl;
+
+   scsp_dsp.exts[0] = cd_in_l;
+   scsp_dsp.exts[1] = cd_in_r;
 
    for (i = 0; i < 128; i++)
       ScspDspExec(&scsp_dsp, i, SoundRam);
@@ -1074,13 +1109,32 @@ s16 generate_sample(struct Scsp * s, int rbp, int rbl)
    for (i = 0; i < 16; i++)
       scsp_dsp.mixs[i] = 0;
 
-   for (i = 0; i<16; i++)
+   for (i = 0; i < 18; i++)//16,17 are exts0/1
    {
-      if (s->slots[i].regs.efsdl)
-         output += scsp_dsp.efreg[i] >> 4;
+      int efsdl = get_sdl_shift(s->slots[i].regs.efsdl);
+
+      s16 efsdl_applied = (scsp_dsp.efreg[i] >> efsdl);
+
+      if (i == 16)
+         efsdl_applied = scsp_dsp.exts[0] >> efsdl;
+
+      if (i == 17)
+         efsdl_applied = scsp_dsp.exts[1] >> efsdl;
+
+      int pan_val_l = 0, pan_val_r = 0;
+      get_panning(s->slots[i].regs.efpan, &pan_val_l, &pan_val_r);
+
+      s16 panned_l = (efsdl_applied >> pan_val_l) >> 2;
+      s16 panned_r = (efsdl_applied >> pan_val_r) >> 2;
+
+      *out_l = *out_l + panned_l;
+      *out_r = *out_r + panned_r;
    }
 
-   return output;
+   int mvol_shift = 0xf - mvol;
+
+   *out_l = *out_l >> mvol_shift;
+   *out_r = *out_r >> mvol_shift;
 }
 #endif
 
@@ -3275,11 +3329,30 @@ scsp_update (s32 *bufL, s32 *bufR, u32 len)
    scsp_buf_len = len;
    scsp_buf_pos = 0;
 
+   s32 temp = cdda_next_in - cdda_out_left;
+   s32 outpos = (temp < 0) ? temp + sizeof(cddabuf.data) : temp;
+   u8 *buf = &cddabuf.data[outpos];
+
    for (; scsp_buf_pos < scsp_buf_len; scsp_buf_pos++)
    {
-      s16 out = generate_sample(&new_scsp, scsp.rbp,scsp.rbl);
-      scsp_bufL[scsp_buf_pos] += out;
-      scsp_bufR[scsp_buf_pos] += out;
+      s16 out_l = 0;
+      s16 out_r = 0;
+
+      s16 cd_in_l = 0;
+      s16 cd_in_r = 0;
+
+      if ((s32)cdda_out_left > 0)
+      {
+         cd_in_l = (s16)((buf[1] << 8) | buf[0]);
+         cd_in_r = (s16)((buf[3] << 8) | buf[2]);
+
+         cdda_out_left -= 4;
+         buf += 4;
+      }
+
+      generate_sample(&new_scsp, scsp.rbp,scsp.rbl, &out_l, &out_r, scsp.mvol, cd_in_l, cd_in_r);
+      scsp_bufL[scsp_buf_pos] += out_l;
+      scsp_bufR[scsp_buf_pos] += out_r;
    }
 #else
   slot_t *slot;

--- a/yabause/src/scsp.c
+++ b/yabause/src/scsp.c
@@ -117,6 +117,950 @@
 # define FLUSH_SCSP()  /*nothing*/
 #endif
 
+#ifdef USE_NEW_SCSP
+enum EnvelopeStates
+{
+   ATTACK,
+   DECAY1,
+   DECAY2,
+   RELEASE
+};
+
+//0x30 to 0x3f only
+const u8 attack_rate_table[][4] =
+{
+   { 4,4,4,4 },//0x30
+   { 3,4,4,4 },
+   { 3,4,3,4 },
+   { 3,3,3,4 },
+
+   { 3,3,3,3 },
+   { 2,3,3,3 },
+   { 2,3,2,3 },
+   { 2,2,2,3 },
+
+   { 2,2,2,2 },
+   { 1,2,2,2 },
+   { 1,2,1,2 },
+   { 1,1,1,2 },
+
+   { 1,1,1,1 },//0x3c
+   { 1,1,1,1 },//0x3d
+   { 1,1,1,1 },//0x3e
+   { 1,1,1,1 },//0x3f
+};
+
+const u8 decay_rate_table[][4] =
+{
+   { 1,1,1,1 },//0x30
+   { 2,1,1,1 },
+   { 2,1,2,1 },
+   { 2,2,2,1 },
+
+   { 2,2,2,2 },
+   { 4,2,2,2 },
+   { 4,2,4,2 },
+   { 4,4,4,2 },
+
+   { 4,4,4,4 },
+   { 8,4,4,4 },
+   { 8,4,8,4 },
+   { 8,8,8,4 },
+
+   { 8,8,8,8 },//0x3c
+   { 8,8,8,8 },//0x3d
+   { 8,8,8,8 },//0x3e
+   { 8,8,8,8 },//0x3f
+};
+
+//effective rate step table
+//settings 0x2 to 0x5, then repeats with bigger shifts
+//int_max represents going back to the beginning of a row since
+//the number of steps is not the same for each setting
+#define MAKE_TABLE(SHIFT) \
+   { 8192 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, INT_MAX,INT_MAX,INT_MAX,INT_MAX, INT_MAX }, \
+   { 8192 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, INT_MAX }, \
+   { 4096 >> SHIFT, INT_MAX,INT_MAX,INT_MAX,INT_MAX, INT_MAX,INT_MAX , INT_MAX }, \
+   { 4096 >> SHIFT, 4096 >> SHIFT, 4096 >> SHIFT, 2048 >> SHIFT, 2048 >> SHIFT, INT_MAX, INT_MAX, INT_MAX },
+
+const int envelope_table[][8] =
+{
+   MAKE_TABLE(0)
+   MAKE_TABLE(1)
+   MAKE_TABLE(2)
+   MAKE_TABLE(3)
+   MAKE_TABLE(4)
+   MAKE_TABLE(5)
+   MAKE_TABLE(6)
+   MAKE_TABLE(7)
+   MAKE_TABLE(8)
+   MAKE_TABLE(9)
+   MAKE_TABLE(10)
+   MAKE_TABLE(11)
+   MAKE_TABLE(12)
+};
+
+//unknown stored bits are unknown1-5
+struct SlotRegs
+{
+   u8 kx;
+   u8 kb;
+   u8 sbctl;
+   u8 ssctl;
+   u8 lpctl;
+   u8 pcm8b;
+   u32 sa;
+   u16 lsa;
+   u16 lea;
+   u8 d2r;
+   u8 d1r;
+   u8 hold;
+   u8 ar;
+   u8 unknown1;
+   u8 ls;
+   u8 krs;
+   u8 dl;
+   u8 rr;
+   u8 unknown2;
+   u8 si;
+   u8 sd;
+   u16 tl;
+   u8 mdl;
+   u8 mdxsl;
+   u8 mdysl;
+   u8 unknown3;
+   u8 oct;
+   u8 unknown4;
+   u16 fns;
+   u8 re;
+   u8 lfof;
+   u8 plfows;
+   u8 plfos;
+   u8 alfows;
+   u8 alfos;
+   u8 unknown5;
+   u8 isel;
+   u8 imxl;
+   u8 disdl;
+   u8 dipan;
+   u8 efsdl;
+   u8 efpan;
+};
+
+struct SlotState
+{
+   u16 wave;
+   int backwards;
+   enum EnvelopeStates envelope;
+   s16 output;
+   u16 attenuation;
+   int step_count;
+   u32 sample_counter;
+   u32 envelope_steps_taken;
+   s32 waveform_phase_value;
+   s32 sample_offset;
+   u32 address_pointer;
+
+   int num;
+   int is_muted;
+};
+
+struct Slot
+{
+   //registers
+   struct SlotRegs regs;
+
+   //internal state
+   struct SlotState state;
+};
+
+struct Scsp
+{
+   u16 sound_stack[64];
+   struct Slot slots[32];
+}new_scsp;
+
+//pg, plfo
+void op1(struct Slot * slot)
+{
+   u32 oct = slot->regs.oct ^ 8;
+   u32 fns = slot->regs.fns ^ 0x400;
+   u32 phase_increment = fns << oct;
+
+   if (slot->state.attenuation > 0x3bf)
+      return;
+
+   slot->state.waveform_phase_value &= (1 << 18) - 1;//18 fractional bits
+   slot->state.waveform_phase_value += phase_increment;
+}
+
+int get_slot(struct Slot * slot, int mdsl)
+{
+   return (mdsl + slot->state.num) & 0x1f;
+}
+
+//address pointer calculation
+//modulation data read
+void op2(struct Slot * slot, struct Scsp * s)
+{
+   s32 md_out = 0;
+   s32 sample_delta = slot->state.waveform_phase_value >> 18;
+
+   if (slot->state.attenuation > 0x3bf)
+      return;
+
+   if (slot->regs.mdl)
+   {
+      //averaging operation
+      u32 x_sel = get_slot(slot, slot->regs.mdxsl);
+      u32 y_sel = get_slot(slot, slot->regs.mdysl);
+      s16 xd = s->sound_stack[x_sel];
+      s16 yd = s->sound_stack[y_sel];
+
+      s32 zd = (xd + yd) / 2;
+
+      //modulation operation
+      u16 shift = 0xf - (slot->regs.mdl);
+      zd >>= shift;
+
+      md_out = zd;
+   }
+
+   //address pointer
+
+   if (slot->regs.lpctl == 0)//no loop
+   {
+      slot->state.sample_offset += sample_delta;
+
+      if (slot->state.sample_offset >= slot->regs.lea)
+         slot->state.attenuation = 0x3ff;
+   }
+   else if (slot->regs.lpctl == 1)//normal loop
+   {
+      slot->state.sample_offset += sample_delta;
+
+      if (slot->state.sample_offset >= slot->regs.lea)
+         slot->state.sample_offset = slot->regs.lsa;
+   }
+   else if (slot->regs.lpctl == 2)//reverse
+   {
+      if (!slot->state.backwards)
+         slot->state.sample_offset += sample_delta;
+      else
+         slot->state.sample_offset -= sample_delta;
+
+      if (!slot->state.backwards)
+      {
+         if (slot->state.sample_offset >= slot->regs.lea)
+         {
+            slot->state.sample_offset = slot->regs.lea;
+            slot->state.backwards = 1;
+         }
+      }
+      else
+      {
+         //backwards
+         if (slot->state.sample_offset <= slot->regs.lsa)
+            slot->state.sample_offset = slot->regs.lea;
+      }
+   }
+   else if (slot->regs.lpctl == 3)//ping pong
+   {
+      if(!slot->state.backwards)
+         slot->state.sample_offset += sample_delta;
+      else
+         slot->state.sample_offset -= sample_delta;
+
+      if (!slot->state.backwards)
+      {
+         if (slot->state.sample_offset >= slot->regs.lea)
+         {
+            slot->state.sample_offset = slot->regs.lea;
+            slot->state.backwards = 1;
+         }
+      }
+      else
+      {
+         if (slot->state.sample_offset <= slot->regs.lsa)
+         {
+            slot->state.sample_offset = slot->regs.lsa;
+            slot->state.backwards = 0;
+         }
+      }
+   }
+
+   if (!slot->regs.pcm8b)
+      slot->state.address_pointer = (s32)slot->regs.sa + (slot->state.sample_offset + md_out) * 2;
+   else
+      slot->state.address_pointer = (s32)slot->regs.sa + (slot->state.sample_offset + md_out);
+}
+
+//waveform dram read
+void op3(struct Slot * slot)
+{
+   u32 addr = (slot->state.address_pointer) & 0x7FFFF;
+
+   if (slot->state.attenuation > 0x3bf)
+      return;
+
+   if (!slot->regs.pcm8b)
+      slot->state.wave = SoundRamReadWord(addr);
+   else
+      slot->state.wave = SoundRamReadByte(addr) << 8;
+
+   slot->state.output = slot->state.wave;
+}
+
+void change_envelope_state(struct Slot * slot, enum EnvelopeStates new_state)
+{
+   slot->state.envelope = new_state;
+   slot->state.step_count = 0;
+}
+
+int need_envelope_step(int effective_rate, u32 sample_counter, struct Slot* slot)
+{
+   if (sample_counter == 0)
+      return 0;
+
+   if (effective_rate == 0 || effective_rate == 1)
+   {
+      return 0;//never step
+   }
+   else if (effective_rate >= 0x30)
+   {
+      if ((sample_counter & 1) == 0)
+      {
+         slot->state.envelope_steps_taken++;
+         return 1;
+      }
+      else
+         return 0;
+   }
+   else
+   {
+      int pos = effective_rate - 2;
+
+      int result = 0;
+
+      int value = envelope_table[pos][slot->state.step_count];
+
+      if (sample_counter % value == 0)
+      {
+         result = 1;
+
+         slot->state.envelope_steps_taken++;
+         slot->state.step_count++;
+
+         if (envelope_table[pos][slot->state.step_count] == INT_MAX)
+            slot->state.step_count = 0;//reached the end of the array
+      }
+
+      return result;
+   }
+   return 0;
+}
+
+s32 get_rate(struct Slot * slot, int rate)
+{
+   s32 result = 0;
+
+   if (slot->regs.krs == 0xf)
+      result = rate * 2;
+   else
+   {
+      result = (slot->regs.krs * 2) + (rate * 2) + ((slot->regs.fns >> 9) & 1);
+      result = (8 ^ slot->regs.oct) + (result - 8);
+   }
+
+   if (result <= 0)
+      return 0;
+
+   if (result >= 0x3c)
+      return 0x3c;
+
+   return result;
+}
+
+void do_decay(struct Slot * slot, int rate_in)
+{
+   int rate = get_rate(slot, rate_in);
+   int sample_mod_4 = slot->state.envelope_steps_taken & 3;
+   int decay_rate;
+
+   if (rate <= 0x30)
+      decay_rate = decay_rate_table[0][sample_mod_4];
+   else
+      decay_rate = decay_rate_table[rate - 0x30][sample_mod_4];
+
+   if (need_envelope_step(rate, slot->state.sample_counter, slot))
+   {
+      if (slot->state.attenuation < 0x3bf)
+         slot->state.attenuation += decay_rate;
+   }
+}
+
+//interpolation
+//eg
+void op4(struct Slot * slot)
+{
+   int sample_mod_4 = slot->state.envelope_steps_taken & 3;
+
+   if (slot->state.attenuation >= 0x3bf)
+      return;
+
+   if (slot->state.envelope == ATTACK)
+   {
+      int rate = get_rate(slot, slot->regs.ar);
+      int need_step = need_envelope_step(rate, slot->state.sample_counter, slot);
+
+      if (need_step)
+      {
+         int attack_rate = 0;
+
+         if (rate <= 0x30)
+            attack_rate = attack_rate_table[0][sample_mod_4];
+         else
+            attack_rate = attack_rate_table[rate - 0x30][sample_mod_4];
+
+         slot->state.attenuation -= ((slot->state.attenuation >> attack_rate)) + 1;
+
+         if (slot->state.attenuation == 0)
+            change_envelope_state(slot, DECAY1);
+      }
+   }
+   else if (slot->state.envelope == DECAY1)
+   {
+      do_decay(slot,slot->regs.d1r);
+
+      if ((slot->state.attenuation >> 5) >= slot->regs.dl)
+         change_envelope_state(slot, DECAY2);
+   }
+   else if (slot->state.envelope == DECAY2)
+      do_decay(slot, slot->regs.d2r);
+   else if (slot->state.envelope == RELEASE)
+      do_decay(slot, slot->regs.rr);
+}
+
+s16 apply_volume(u16 tl, u16 slot_att, const s16 s)
+{
+   u32 tl_att = tl * 4;
+   u32 att_clipped = 0;
+   s32 sample_att = 0;
+   u32 shift = 0;
+
+   tl_att += slot_att;
+
+   att_clipped = tl_att;
+   att_clipped &= 0x3f;
+   att_clipped ^= 0x7f;
+   att_clipped += 1;
+
+   sample_att = s * att_clipped;
+   shift = tl_att >> 6;
+
+   sample_att = sample_att >> (shift + 7);
+
+   return sample_att;
+}
+
+//level 1
+void op5(struct Slot * slot)
+{
+   if (slot->state.attenuation > 0x3bf)
+   {
+      slot->state.output = 0;
+      return;
+   }
+   else
+   {
+      s16 sample = apply_volume(slot->regs.tl, slot->state.attenuation, slot->state.output);
+      slot->state.output = sample;
+   }
+}
+
+//level 2
+void op6(struct Slot * slot)
+{
+
+}
+
+//sound stack write
+void op7(struct Slot * slot, struct Scsp*s)
+{
+   u32 previous = s->sound_stack[slot->state.num + 32];
+   s->sound_stack[slot->state.num + 32] = slot->state.output;
+   s->sound_stack[slot->state.num] = previous;
+
+   slot->state.sample_counter++;
+}
+
+void keyon(struct Slot * slot)
+{
+   if (slot->state.envelope == RELEASE || slot->state.attenuation > 0x3BF)
+   {
+      slot->state.envelope = ATTACK;
+      slot->state.attenuation = 0x280;
+      slot->state.sample_counter = 0;
+      slot->state.step_count = 0;
+      slot->state.sample_offset = 0;
+      slot->state.envelope_steps_taken = 0;
+   }
+   //otherwise ignore
+}
+
+void keyoff(struct Slot * slot)
+{
+   change_envelope_state(slot, RELEASE);
+}
+
+void keyonex(struct Scsp *s)
+{
+   int channel;
+   for (channel = 0; channel < 32; channel++)
+   {
+      if (s->slots[channel].regs.kb)
+         keyon(&s->slots[channel]);
+      else
+         keyoff(&s->slots[channel]);
+   }
+}
+
+void scsp_slot_write_byte(struct Scsp *s, u32 addr, u8 data)
+{
+   int slot_num = (addr >> 5) & 0x1f;
+   struct Slot * slot = &s->slots[slot_num];
+   u32 offset = (addr - (0x20 * slot_num));
+
+   switch (offset)
+   {
+   case 0:
+      slot->regs.kb = (data >> 3) & 1;//has to be done first
+
+      if ((data >> 4) & 1)//keyonex
+         keyonex(s);
+
+      slot->regs.sbctl = (data >> 1) & 3;
+      slot->regs.ssctl = (slot->regs.ssctl & 1) | ((data & 1) << 1);
+      break;
+   case 1:
+      slot->regs.ssctl = (slot->regs.ssctl & 2) | ((data >> 7) & 1);
+      slot->regs.lpctl = (data >> 5) & 3;
+      slot->regs.pcm8b = (data >> 4) & 1;
+      slot->regs.sa = (slot->regs.sa & 0xffff) | ((data & 0xf) << 16);
+      break;
+   case 2:
+      slot->regs.sa = (slot->regs.sa & 0xf00ff) | (data << 8);
+      break;
+   case 3:
+      slot->regs.sa = (slot->regs.sa & 0xfff00) | data;
+      break;
+   case 4:
+      slot->regs.lsa = (slot->regs.lsa & 0x00ff) | (data << 8);
+      break;
+   case 5:
+      slot->regs.lsa = (slot->regs.lsa & 0xff00) | data;
+      break;
+   case 6:
+      slot->regs.lea = (slot->regs.lea & 0x00ff) | (data << 8);
+      break;
+   case 7:
+      slot->regs.lea = (slot->regs.lea & 0xff00) | data;
+      break;
+   case 8:
+      slot->regs.d2r = (data >> 3) & 0x1f;
+      slot->regs.d1r = (slot->regs.d1r & 3) | ((data & 0x7) << 2);
+      break;
+   case 9:
+      slot->regs.d1r = (slot->regs.d1r & 0x1c) | ((data >> 6) & 3);
+      slot->regs.hold = (data >> 5) & 1;
+      slot->regs.ar = data & 0x1f;
+      break;
+   case 10:
+      slot->regs.unknown1 = (data >> 7) & 1;
+      slot->regs.ls = (data >> 6) & 1;
+      slot->regs.krs = (data >> 2) & 0xf;
+      slot->regs.dl = (slot->regs.dl & 0x7) | ((data & 3) << 3);
+      break;
+   case 11:
+      slot->regs.dl = (slot->regs.dl & 0x18) | ((data >> 5) & 7);
+      slot->regs.rr = data & 0x1f;
+      break;
+   case 12:
+      slot->regs.unknown2 = (data >> 2) & 3;
+      slot->regs.si = (data >> 1) & 1;
+      slot->regs.sd = data & 1;
+      break;
+   case 13:
+      slot->regs.tl = data;
+      break;
+   case 14:
+      slot->regs.mdl = (data >> 4) & 0xf;
+      slot->regs.mdxsl = (slot->regs.mdxsl & 0x3) | ((data & 0xf) << 2);
+      break;
+   case 15:
+      slot->regs.mdxsl = (slot->regs.mdxsl & 0x3C) | (data >> 6) & 3;
+      slot->regs.mdysl = data & 0x3f;
+      break;
+   case 16:
+      slot->regs.unknown3 = (data >> 7) & 1;
+      slot->regs.oct = (data >> 3) & 0xf;
+      slot->regs.unknown4 = (data >> 2) & 1;
+      slot->regs.fns = (slot->regs.fns & 0xff) | ((data & 3) << 8);
+      break;
+   case 17:
+      slot->regs.fns = (slot->regs.fns & 0x300) | data;
+      break;
+   case 18:
+      slot->regs.re = (data >> 7) & 1;
+      slot->regs.lfof = (data >> 2) & 0x1f;
+      slot->regs.plfows = data & 3;
+      break;
+   case 19:
+      slot->regs.plfos = (data >> 5) & 7;
+      slot->regs.alfows = (data >> 3) & 3;
+      slot->regs.alfos = data & 7;
+      break;
+   case 20:
+      //nothing here
+      break;
+   case 21:
+      slot->regs.unknown5 = (data >> 7) & 1;
+      slot->regs.isel = (data >> 3) & 0xf;
+      slot->regs.imxl = data & 7;
+      break;
+   case 22:
+      slot->regs.disdl = (data >> 5) & 7;
+      slot->regs.dipan = data & 0x1f;
+      break;
+   case 23:
+      slot->regs.efsdl = (data >> 5) & 7;
+      slot->regs.efpan = data & 0x1f;
+      break;
+   default:
+      break;
+   }
+}
+
+u8 scsp_slot_read_byte(struct Scsp *s, u32 addr)
+{
+   int slot_num = (addr >> 5) & 0x1f;
+   struct Slot * slot = &s->slots[slot_num];
+   u32 offset = (addr - (0x20 * slot_num));
+   u8 data = 0;
+
+   switch (offset)
+   {
+   case 0:
+      data |= slot->regs.kb << 3;
+      data |= slot->regs.sbctl << 1;
+      data |= (slot->regs.ssctl >> 1) & 1;
+      break;
+   case 1:
+      data |= (slot->regs.ssctl & 1) << 7;
+      data |= slot->regs.lpctl << 5;
+      data |= slot->regs.pcm8b << 4;
+      data |= (slot->regs.sa & 0xf0000) >> 16;
+      break;
+   case 2:
+      data |= (slot->regs.sa & 0xff00) >> 8;
+      break;
+   case 3:
+      data |= slot->regs.sa & 0xff;
+      break;
+   case 4:
+      data |= (slot->regs.lsa & 0xff00) >> 8;
+      break;
+   case 5:
+      data |= slot->regs.lsa & 0xff;
+      break;
+   case 6:
+      data |= (slot->regs.lea & 0xff00) >> 8;
+      break;
+   case 7:
+      data |= slot->regs.lea & 0xff;
+      break;
+   case 8:
+      data |= slot->regs.d2r << 3;
+      data |= slot->regs.d1r >> 2;
+      break;
+   case 9:
+      data |= slot->regs.d1r << 6;
+      data |= slot->regs.hold << 5;
+      data |= slot->regs.ar;
+      break;
+   case 10:
+      data |= slot->regs.unknown1 << 7;
+      data |= slot->regs.ls << 6;
+      data |= slot->regs.krs << 2;
+      data |= slot->regs.dl >> 3;
+      break;
+   case 11:
+      data |= slot->regs.dl << 5;
+      data |= slot->regs.rr;
+      break;
+   case 12:
+      data |= slot->regs.unknown2 << 2;
+      data |= slot->regs.si << 1;
+      data |= slot->regs.sd;
+      break;
+   case 13:
+      data |= slot->regs.tl;
+      break;
+   case 14:
+      data |= slot->regs.mdl << 4;
+      data |= slot->regs.mdxsl >> 2;
+      break;
+   case 15:
+      data |= slot->regs.mdxsl << 6;
+      data |= slot->regs.mdysl;
+      break;
+   case 16:
+      data |= slot->regs.unknown3 << 7;
+      data |= slot->regs.oct << 3;
+      data |= slot->regs.unknown4 << 2;
+      data |= slot->regs.fns >> 8;
+      break;
+   case 17:
+      data |= slot->regs.fns;
+      break;
+   case 18:
+      data |= slot->regs.re << 7;
+      data |= slot->regs.lfof << 2;
+      data |= slot->regs.plfows;
+      break;
+   case 19:
+      data |= slot->regs.plfos << 5;
+      data |= slot->regs.alfows << 3;
+      data |= slot->regs.alfos;
+      break;
+   case 20:
+      //nothing
+      break;
+   case 21:
+      data |= slot->regs.unknown5 << 7;
+      data |= slot->regs.isel << 3;
+      data |= slot->regs.imxl;
+      break;
+   case 22:
+      data |= slot->regs.disdl << 5;
+      data |= slot->regs.dipan;
+      break;
+   case 23:
+      data |= slot->regs.efsdl << 5;
+      data |= slot->regs.efpan;
+      break;
+   }
+
+   return data;
+}
+
+void scsp_slot_write_word(struct Scsp *s, u32 addr, u16 data)
+{
+   int slot_num = (addr >> 5) & 0x1f;
+   struct Slot * slot = &s->slots[slot_num];
+   u32 offset = (addr - (0x20 * slot_num));
+
+   switch (offset >> 1)
+   {
+   case 0:
+      slot->regs.kb = (data >> 11) & 1;//has to be done before keyonex
+
+      if (data & (1 << 12))
+         keyonex(s);
+
+      slot->regs.sbctl = (data >> 9) & 3;
+      slot->regs.ssctl = (data >> 7) & 3;
+      slot->regs.lpctl = (data >> 5) & 3;
+      slot->regs.pcm8b = (data >> 4) & 1;
+      slot->regs.sa = (slot->regs.sa & 0xffff) | ((data & 0xf) << 16);
+      break;
+   case 1:
+      slot->regs.sa = (slot->regs.sa & 0xf0000) | data;
+      break;
+   case 2:
+      slot->regs.lsa = data;
+      break;
+   case 3:
+      slot->regs.lea = data;
+      break;
+   case 4:
+      slot->regs.d2r = data >> 11;
+      slot->regs.d1r = (data >> 6) & 0x1f;
+      slot->regs.hold = (data >> 5) & 1;
+      slot->regs.ar = data & 0x1f;
+      break;
+   case 5:
+      slot->regs.unknown1 = (data >> 15) & 1;
+      slot->regs.ls = (data >> 14) & 1;
+      slot->regs.krs = (data >> 10) & 0xf;
+      slot->regs.dl = (data >> 5) & 0x1f;
+      slot->regs.rr = data & 0x1f;
+      break;
+   case 6:
+      slot->regs.unknown2 = (data >> 10) & 3;
+      slot->regs.si = (data >> 9) & 1;
+      slot->regs.sd = (data >> 8) & 1;
+      slot->regs.tl = data & 0xff;
+      break;
+   case 7:
+      slot->regs.mdl = (data >> 12) & 0xf;
+      slot->regs.mdxsl = (data >> 6) & 0x3f;
+      slot->regs.mdysl = data & 0x3f;
+      break;
+   case 8:
+      slot->regs.unknown3 = (data >> 15) & 1;
+      slot->regs.unknown4 = (data >> 10) & 1;
+      slot->regs.oct = (data >> 11) & 0xf;
+      slot->regs.fns = data & 0x3ff;
+      break;
+   case 9:
+      slot->regs.re = (data >> 15) & 1;
+      slot->regs.lfof = (data >> 10) & 0x1f;
+      slot->regs.plfows = (data >> 8) & 3;
+      slot->regs.plfos = (data >> 5) & 7;
+      slot->regs.alfows = (data >> 3) & 3;
+      slot->regs.alfos = data & 7;
+      break;
+   case 10:
+      slot->regs.unknown5 = (data >> 7) & 1;
+      slot->regs.isel = (data >> 3) & 0xf;
+      slot->regs.imxl = data & 7;
+      break;
+   case 11:
+      slot->regs.disdl = (data >> 13) & 7;
+      slot->regs.dipan = (data >> 8) & 0x1f;
+      slot->regs.efsdl = (data >> 5) & 7;
+      slot->regs.efpan = data & 0x1f;
+      break;
+   default:
+      break;
+   }
+}
+
+u16 scsp_slot_read_word(struct Scsp *s, u32 addr)
+{
+   int slot_num = (addr >> 5) & 0x1f;
+   struct Slot * slot = &s->slots[slot_num];
+   u32 offset = (addr - (0x20 * slot_num));
+   u16 data = 0;
+
+   switch (offset >> 1)
+   {
+   case 0:
+      //keyonex not stored
+      data |= slot->regs.kb << 11;
+      data |= slot->regs.sbctl << 9;
+      data |= slot->regs.ssctl << 7;
+      data |= slot->regs.lpctl << 5;
+      data |= slot->regs.pcm8b << 4;
+      data |= (slot->regs.sa >> 16) & 0xf;
+      break;
+   case 1:
+      data = slot->regs.sa & 0xffff;
+      break;
+   case 2:
+      data = slot->regs.lsa;
+      break;
+   case 3:
+      data = slot->regs.lea;
+      break;
+   case 4:
+      data |= slot->regs.d2r << 11;
+      data |= slot->regs.d1r << 6;
+      data |= slot->regs.hold << 5;
+      data |= slot->regs.ar;
+      break;
+   case 5:
+      data |= slot->regs.unknown1 << 15;
+      data |= slot->regs.ls << 14;
+      data |= slot->regs.krs << 10;
+      data |= slot->regs.dl << 5;
+      data |= slot->regs.rr;
+      break;
+   case 6:
+      data |= slot->regs.unknown2 << 10;
+      data |= slot->regs.si << 9;
+      data |= slot->regs.sd << 8;
+      data |= slot->regs.tl;
+      break;
+   case 7:
+      data |= slot->regs.mdl << 12;
+      data |= slot->regs.mdxsl << 6;
+      data |= slot->regs.mdysl;
+      break;
+   case 8:
+      data |= slot->regs.unknown3 << 15;
+      data |= slot->regs.oct << 11;
+      data |= slot->regs.unknown4 << 10;
+      data |= slot->regs.fns;
+      break;
+   case 9:
+      data |= slot->regs.re << 15;
+      data |= slot->regs.lfof << 10;
+      data |= slot->regs.plfows << 8;
+      data |= slot->regs.plfos << 5;
+      data |= slot->regs.alfows << 3;
+      data |= slot->regs.alfos;
+      break;
+   case 10:
+      data |= slot->regs.unknown5 << 7;
+      data |= slot->regs.isel << 3;
+      data |= slot->regs.imxl;
+      break;
+   case 11:
+      data |= slot->regs.disdl << 13;
+      data |= slot->regs.dipan << 8;
+      data |= slot->regs.efsdl << 5;
+      data |= slot->regs.efpan;
+      break;
+   }
+   return data;
+}
+
+s16 generate_sample(struct Scsp * s)
+{
+   static int inited = 0;
+   s16 output = 0;
+   int step_num = 0;
+
+   if (!inited)
+   {
+      int slot_num;
+      memset(&new_scsp, 0, sizeof(struct Scsp));
+
+      for (slot_num = 0; slot_num < 32; slot_num++)
+      {
+         s->slots[slot_num].state.attenuation = 0x3FF;
+         s->slots[slot_num].state.envelope = RELEASE;
+         s->slots[slot_num].state.num = slot_num;
+      }
+
+      inited = 1;
+   }
+
+   //run 32 steps to generate 1 full sample (512 clock cycles at 22579200hz)
+   //7 operations happen simultaneously on different channels due to pipelining
+   for (step_num = 0; step_num < 32; step_num++)
+   {
+      op1(&s->slots[step_num]);//phase, pitch lfo
+      op2(&s->slots[(step_num - 1) & 0x1f],s);//address pointer, modulation data read
+      op3(&s->slots[(step_num - 2) & 0x1f]);//waveform dram read
+      op4(&s->slots[(step_num - 3) & 0x1f]);//interpolation, eg, amplitude lfo
+      op5(&s->slots[(step_num - 4) & 0x1f]);//level calc 1
+      op6(&s->slots[(step_num - 5) & 0x1f]);//level calc 2
+      op7(&s->slots[(step_num - 6) & 0x1f],s);//sound stack write
+
+      if (!s->slots[(step_num - 6) & 0x1f].state.is_muted)
+      {
+         if(s->slots[(step_num - 6) & 0x1f].regs.disdl)
+            output += s->slots[(step_num - 6) & 0x1f].state.output >> 1;
+      }
+   }
+
+   return output;
+}
+#endif
+
 ////////////////////////////////////////////////////////////////
 
 #ifndef PI
@@ -597,6 +1541,10 @@ scsp_slot_refresh_einc (slot_t *slot, u32 adsr_bitmask)
 static void
 scsp_slot_set_b (u32 s, u32 a, u8 d)
 {
+#ifdef USE_NEW_SCSP
+  scsp_slot_write_byte(&new_scsp, a, d);
+#endif
+
   slot_t *slot = &(scsp.slot[s]);
 
   SCSPLOG("slot %d : reg %.2X = %.2X\n", s, a & 0x1F, d);
@@ -890,6 +1838,9 @@ scsp_slot_set_b (u32 s, u32 a, u8 d)
 static void
 scsp_slot_set_w (u32 s, s32 a, u16 d)
 {
+#ifdef USE_NEW_SCSP
+  scsp_slot_write_word(&new_scsp, a, d);
+#endif
   slot_t *slot = &(scsp.slot[s]);
 
   SCSPLOG ("slot %d : reg %.2X = %.4X\n", s, a & 0x1E, d);
@@ -1124,6 +2075,9 @@ scsp_slot_set_w (u32 s, s32 a, u16 d)
 static u8
 scsp_slot_get_b (u32 s, u32 a)
 {
+#ifdef USE_NEW_SCSP
+  return scsp_slot_read_byte(&new_scsp, a);
+#endif
   u8 val = scsp_isr[a ^ 3];
 
   // Mask out keyonx
@@ -1136,6 +2090,9 @@ scsp_slot_get_b (u32 s, u32 a)
 
 static u16 scsp_slot_get_w(u32 s, u32 a)
 {
+#ifdef USE_NEW_SCSP
+  return scsp_slot_read_word(&new_scsp, a);
+#endif
   u16 val = *(u16 *)&scsp_isr[a ^ 2];
 
   if ((a & 0x1E) == 0x00) return val &= 0xEFFF;
@@ -2280,6 +3237,20 @@ static void (*scsp_slot_update_p[2][2][2][2][2])(slot_t *slot) =
 void
 scsp_update (s32 *bufL, s32 *bufR, u32 len)
 {
+#ifdef USE_NEW_SCSP
+   scsp_bufL = bufL;
+   scsp_bufR = bufR;
+
+   scsp_buf_len = len;
+   scsp_buf_pos = 0;
+
+   for (; scsp_buf_pos < scsp_buf_len; scsp_buf_pos++)
+   {
+      s16 out = generate_sample(&new_scsp);
+      scsp_bufL[scsp_buf_pos] += out;
+      scsp_bufR[scsp_buf_pos] += out;
+   }
+#else
   slot_t *slot;
 
   scsp_bufL = bufL;
@@ -2375,15 +3346,22 @@ scsp_update (s32 *bufL, s32 *bufR, u32 len)
   {
 	  SCSPLOG("WARNING: CDDA buffer underrun\n");
   }
+#endif
 }
 
 void
 scsp_update_monitor(void)
 {
+#ifdef USE_NEW_SCSP
+   scsp.ca = new_scsp.slots[scsp.mslc].state.sample_offset >> 5;
+   scsp.sgc = new_scsp.slots[scsp.mslc].state.envelope;
+   scsp.eg = new_scsp.slots[scsp.mslc].state.attenuation >> 5;
+#else
    slot_t *slot = &scsp.slot[scsp.mslc];
    scsp.ca = ((slot->fcnt >> (SCSP_FREQ_LB + 12)) & 0xF) << 7;
    scsp.sgc = slot->ecurp;
    scsp.eg = 0x1f - (slot->env >> (SCSP_ENV_HB - 5));
+#endif
 #ifdef PSP
    WRITE_THROUGH(scsp.ca);
    WRITE_THROUGH(scsp.sgc);
@@ -2776,7 +3754,10 @@ scsp_r_w (u32 a)
     }
   else if (a < 0x700)
     {
-
+#ifdef USE_NEW_SCSP
+       u32 addr = a - 0x600;
+       return new_scsp.sound_stack[(addr/2)&0x3f];
+#endif
     }
   else if (a >= 0x700 && a < 0x780)
   {

--- a/yabause/src/scsp.h
+++ b/yabause/src/scsp.h
@@ -144,4 +144,10 @@ int M68KDelCodeBreakpoint(u32 addr);
 m68kcodebreakpoint_struct *M68KGetBreakpointList(void);
 void M68KClearCodeBreakpoints(void);
 
+void scsp_debug_instrument_get_data(int i, u32 * sa, int * is_muted);
+void scsp_debug_instrument_set_mute(u32 sa, int mute);
+void scsp_debug_instrument_clear();
+void scsp_debug_get_envelope(int chan, int * env, int * state);
+void scsp_debug_set_mode(int mode);
+
 #endif

--- a/yabause/src/scspdsp.c
+++ b/yabause/src/scspdsp.c
@@ -23,6 +23,18 @@
 s32 float_to_int(u16 f_val);
 u16 int_to_float(u32 i_val);
 
+//saturate 24 bit signed integer
+static INLINE s32 saturate_24(s32 value)
+{
+   if (value > 8388607)
+      value = 8388607;
+
+   if (value < (-8388608))
+      value = (-8388608);
+
+   return value;
+}
+
 void ScspDspExec(ScspDsp* dsp, int addr, u8 * sound_ram)
 {
    u16* sound_ram_16 = (u16*)sound_ram;
@@ -82,9 +94,9 @@ void ScspDspExec(ScspDsp* dsp, int addr, u8 * sound_ram)
       dsp->y_reg = dsp->inputs;
 
    if (instruction.part.shift == 0)
-      dsp->shifted = dsp->acc;
+      dsp->shifted = saturate_24(dsp->acc);
    else if (instruction.part.shift == 1)
-      dsp->shifted = dsp->acc * 2;
+      dsp->shifted = saturate_24(dsp->acc * 2);
    else if (instruction.part.shift == 2)
       dsp->shifted = (dsp->acc * 2) & 0xffffff;
    else if (instruction.part.shift == 2)

--- a/yabause/src/scspdsp.c
+++ b/yabause/src/scspdsp.c
@@ -20,6 +20,220 @@
 #include "scsp.h"
 #include "scspdsp.h"
 
+s32 float_to_int(u16 f_val);
+u16 int_to_float(u32 i_val);
+
+void ScspDspExec(ScspDsp* dsp, int addr, u8 * sound_ram)
+{
+   u16* sound_ram_16 = (u16*)sound_ram;
+   u64 mul_temp = 0;
+
+   union ScspDspInstruction instruction;
+   instruction.all = scsp_dsp.mpro[addr];
+
+   if (instruction.part.ira >= 0 && instruction.part.ira <= 0x1f)
+      dsp->inputs = dsp->mems[instruction.part.ira & 0x1f];
+   else if (instruction.part.ira >= 0x20 && instruction.part.ira <= 0x2f)
+      dsp->inputs = dsp->mixs[instruction.part.ira - 0x20] << 4;
+   else if (instruction.part.ira == 0x30 || instruction.part.ira == 0x31)
+      dsp->inputs = dsp->exts[(instruction.part.ira - 0x30) & 1];
+
+   if (instruction.part.iwt)
+      dsp->mems[instruction.part.iwa] = dsp->mrd_value;
+
+   if (instruction.part.bsel == 0)
+   {
+      s32 temp_val = dsp->temp[(instruction.part.tra + dsp->mdec_ct) & 0x7f];
+
+      if (temp_val & 0x800000)
+         temp_val |= 0x3000000;//sign extend to 26 bits
+
+      dsp->b = temp_val;
+   }
+   else if (instruction.part.bsel == 1)
+      dsp->b = dsp->acc;
+
+   if (instruction.part.negb)
+      dsp->b = 0 - dsp->b;
+
+   if (instruction.part.zero)
+      dsp->b = 0;
+
+   if (instruction.part.xsel == 0)
+      dsp->x = dsp->temp[(instruction.part.tra + dsp->mdec_ct) & 0x7f];
+   else if (instruction.part.xsel == 1)
+      dsp->x = dsp->inputs;
+
+   if (instruction.part.ysel == 0)
+      dsp->y = dsp->frc_reg;
+   else if (instruction.part.ysel == 1)
+   {
+      dsp->y = dsp->coef[instruction.part.coef] >> 3;
+
+      if (dsp->coef[instruction.part.coef] & 0x8000)
+         dsp->y |= 0xE000;
+   }
+   else if (instruction.part.ysel == 2)
+      dsp->y = (dsp->y_reg >> 11) & 0x1FFF;
+   else if (instruction.part.ysel == 3)
+      dsp->y = (dsp->y_reg >> 4) & 0xFFF;
+
+   if (instruction.part.yrl)
+      dsp->y_reg = dsp->inputs;
+
+   if (instruction.part.shift == 0)
+      dsp->shifted = dsp->acc;
+   else if (instruction.part.shift == 1)
+      dsp->shifted = dsp->acc * 2;
+   else if (instruction.part.shift == 2)
+      dsp->shifted = (dsp->acc * 2) & 0xffffff;
+   else if (instruction.part.shift == 2)
+      dsp->shifted = dsp->acc & 0xffffff;
+
+   mul_temp = (u64)dsp->x * (u64)dsp->y;//prevent clipping
+   dsp->acc = (mul_temp >> 12) + dsp->b;
+
+   dsp->acc &= 0xffffff;
+
+   if (dsp->acc & 0x800000)
+      dsp->acc |= 0xff000000;
+
+   if (instruction.part.twt)
+      dsp->temp[(instruction.part.twa + dsp->mdec_ct) & 0x7f] = dsp->shifted;
+
+   if (instruction.part.frcl)
+   {
+      if (instruction.part.shift == 3)
+         dsp->frc_reg = dsp->shifted & 0xFFF;
+      else
+         dsp->frc_reg = (dsp->shifted >> 11) & 0x1FFF;
+   }
+
+   if (instruction.part.mrd || instruction.part.mwt)
+   {
+      u32 address = dsp->madrs[instruction.part.masa];
+
+      if (instruction.part.table == 0)
+         address += dsp->mdec_ct;
+
+      if (instruction.part.adreb)
+         address += dsp->adrs_reg & 0xfff;
+
+      if (instruction.part.nxadr)
+         address += 1;
+
+      if (instruction.part.table == 0)
+      {
+         if (dsp->rbl == 0)
+            address &= 0x1fff;
+         else if (dsp->rbl == 1)
+            address &= 0x3fff;
+         else if (dsp->rbl == 2)
+            address &= 0x7fff;
+         else if (dsp->rbl == 3)
+            address &= 0xffff;
+      }
+      else if (instruction.part.table == 1)
+         address &= 0xffff;
+
+      address += (dsp->rbp << 11) * 2;
+
+      if (instruction.part.mrd)
+      {
+         u16 temp = sound_ram_16[address & 0x7ffff];
+         dsp->mrd_value = float_to_int(temp);
+      }
+
+      if (instruction.part.mwt)
+      {
+         s32 shifted_val = dsp->shifted;
+         shifted_val = int_to_float(shifted_val);
+         sound_ram_16[address & 0x7ffff] = shifted_val;
+      }
+   }
+
+   if (instruction.part.adrl)
+   {
+      if (instruction.part.shift == 3)
+         dsp->adrs_reg = dsp->inputs >> 16;
+      else
+         dsp->adrs_reg = (dsp->shifted >> 12) & 0xFFF;
+   }
+
+   if (instruction.part.ewt)
+      dsp->efreg[instruction.part.ewa] = dsp->shifted >> 8;
+}
+
+//sign extended to 32 bits instead of 24
+s32 float_to_int(u16 f_val)
+{
+   u32 sign = (f_val >> 15) & 1;
+   u32 sign_inverse = (!sign) & 1;
+   u32 exponent = (f_val >> 11) & 0xf;
+   u32 mantissa = f_val & 0x7FF;
+
+   s32 ret_val = sign << 31;
+
+   if (exponent > 11)
+   {
+      exponent = 11;
+      ret_val |= (sign << 30);
+   }
+   else
+      ret_val |= (sign_inverse << 30);
+
+   ret_val |= mantissa << 19;
+
+   ret_val = ret_val >> (exponent + (1 << 3));
+
+   return ret_val;
+}
+
+u16 int_to_float(u32 i_val)
+{
+   u32 sign = (i_val >> 23) & 1;
+   u32 exponent = 0;
+
+   if (sign != 0)
+      i_val = (~i_val) & 0x7FFFFF;
+
+   if (i_val <= 0x1FFFF)
+   {
+      i_val *= 64;
+      exponent += 0x3000;
+   }
+
+   if (i_val <= 0xFFFFF)
+   {
+      i_val *= 8;
+      exponent += 0x1800;
+   }
+
+   if (i_val <= 0x3FFFFF)
+   {
+      i_val *= 2;
+      exponent += 0x800;
+   }
+
+   if (i_val <= 0x3FFFFF)
+   {
+      i_val *= 2;
+      exponent += 0x800;
+   }
+
+   if (i_val <= 0x3FFFFF)
+      exponent += 0x800;
+
+   i_val >>= 11;
+   i_val &= 0x7ff;
+   i_val |= exponent;
+
+   if (sign != 0)
+      i_val ^= (0x7ff | (1 << 15));
+
+   return i_val;
+}
+
 int ScspDspAssembleGetValue(char* instruction)
 {
    char temp[512] = { 0 };
@@ -108,7 +322,7 @@ u64 ScspDspAssembleLine(char* line)
    {
       instruction.part.frcl = 1;
    }
-   
+
    if ((temp = strstr(line, "shift")))
    {
       instruction.part.shift = ScspDspAssembleGetValue(temp);

--- a/yabause/src/scspdsp.h
+++ b/yabause/src/scspdsp.h
@@ -24,9 +24,30 @@
 
 typedef struct
 {
-   u64 mpro[128];
    u16 coef[64];
    u16 madrs[32];
+   u64 mpro[128];
+   s32 temp[128];
+   s32 mems[32];
+   s32 mixs[16];
+   s16 efreg[16];
+   s16 exts[2];
+
+   u32 mdec_ct;
+   s32 inputs;
+   s32 b;
+   s32 x;
+   s16 y;
+   s32 acc;
+   s32 shifted;
+   s32 y_reg;
+   u16 frc_reg;
+   u16 adrs_reg;
+
+   u32 mrd_value;
+
+   int rbl;
+   int rbp;
 }ScspDsp;
 
 //dsp instruction format
@@ -121,6 +142,7 @@ union ScspDspInstruction {
 #endif
 
 void ScspDspDisasm(u8 addr, char *outstring);
+void ScspDspExec(ScspDsp* dsp, int addr, u8 * sound_ram);
 
 extern ScspDsp scsp_dsp;
 

--- a/yabause/src/vdp1.c
+++ b/yabause/src/vdp1.c
@@ -575,6 +575,7 @@ int Vdp1SaveState(FILE *fp)
    int i = 0;
    u8 back_framebuffer[0x40000] = { 0 };
 #endif
+
    offset = StateWriteHeader(fp, "VDP1", 1);
 
    // Write registers
@@ -582,6 +583,7 @@ int Vdp1SaveState(FILE *fp)
 
    // Write VDP1 ram
    ywrite(&check, (void *)Vdp1Ram, 0x80000, 1, fp);
+
 #ifdef IMPROVED_SAVESTATES
    for (i = 0; i < 0x40000; i++)
       back_framebuffer[i] = Vdp1FrameBufferReadByte(i);
@@ -600,6 +602,7 @@ int Vdp1LoadState(FILE *fp, UNUSED int version, int size)
    int i = 0;
    u8 back_framebuffer[0x40000] = { 0 };
 #endif
+
    // Read registers
    yread(&check, (void *)Vdp1Regs, sizeof(Vdp1), 1, fp);
 
@@ -1380,6 +1383,7 @@ void VIDDummyVdp2DrawScreens(void);
 void VIDDummyGetGlSize(int *width, int *height);
 void VIDDummVdp1ReadFrameBuffer(u32 type, u32 addr, void * out);
 void VIDDummVdp1WriteFrameBuffer(u32 type, u32 addr, u32 val);
+void VIDDummyGetNativeResolution(int *width, int * height, int *interlace);
 
 VideoInterface_struct VIDDummy = {
 VIDCORE_DUMMY,
@@ -1406,7 +1410,8 @@ VIDDummyVdp2Reset,
 VIDDummyVdp2DrawStart,
 VIDDummyVdp2DrawEnd,
 VIDDummyVdp2DrawScreens,
-VIDDummyGetGlSize
+VIDDummyGetGlSize,
+VIDDummyGetNativeResolution
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1551,4 +1556,13 @@ void VIDDummVdp1ReadFrameBuffer(u32 type, u32 addr, void * out)
 
 void VIDDummVdp1WriteFrameBuffer(u32 type, u32 addr, u32 val)
 {
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void VIDDummyGetNativeResolution(int *width, int * height, int * interlace)
+{
+   *width = 0;
+   *height = 0;
+   *interlace = 0;
 }

--- a/yabause/src/vdp1.h
+++ b/yabause/src/vdp1.h
@@ -85,6 +85,7 @@ typedef struct
    void (*Vdp2DrawEnd)(void);
    void (*Vdp2DrawScreens)(void);
    void (*GetGlSize)(int *width, int *height);
+   void (*GetNativeResolution)(int *width, int *height, int * interlace);
 } VideoInterface_struct;
 
 extern VideoInterface_struct *VIDCore;

--- a/yabause/src/vdp2.c
+++ b/yabause/src/vdp2.c
@@ -40,6 +40,7 @@ Vdp2 * Vdp2Regs;
 Vdp2Internal_struct Vdp2Internal;
 Vdp2External_struct Vdp2External;
 
+struct CellScrollData cell_scroll_data[270];
 Vdp2 Vdp2Lines[270];
 
 static int autoframeskipenab=0;
@@ -284,10 +285,19 @@ void Vdp2HBlankIN(void) {
 //////////////////////////////////////////////////////////////////////////////
 
 void Vdp2HBlankOUT(void) {
+   int i;
    Vdp2Regs->TVSTAT &= ~0x0004;
 
    if (yabsys.LineCount < 270)
+   {
+      u32 cell_scroll_table_start_addr = (Vdp2Regs->VCSTA.all & 0x7FFFE) << 1;
       memcpy(Vdp2Lines + yabsys.LineCount, Vdp2Regs, sizeof(Vdp2));
+
+      for (i = 0; i < 88; i++)
+      {
+         cell_scroll_data[yabsys.LineCount].data[i] = Vdp2RamReadLong(cell_scroll_table_start_addr + i * 4);
+      }
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/yabause/src/vdp2.h
+++ b/yabause/src/vdp2.h
@@ -364,6 +364,13 @@ extern u64 lastticks;
 extern int vdp2_is_odd_frame;
 extern Vdp2 Vdp2Lines[270];
 
+struct CellScrollData
+{
+   u32 data[88];//(352/8) * 2 screens
+};
+
+extern struct CellScrollData cell_scroll_data[270];
+
 // struct for Vdp2 part that shouldn't be saved
 typedef struct {
    int disptoggle;

--- a/yabause/src/vidshared.h
+++ b/yabause/src/vidshared.h
@@ -183,7 +183,7 @@ typedef struct
    vdp2rotationparameter_struct * FASTCALL (*GetRParam)(void *, int h,int v);
    u32 LineColorBase;
 
-   void (*LoadLineParams)(void *, int line, Vdp2* lines);
+   void (*LoadLineParams)(void *, void *, int line, Vdp2* lines);
 
    int bad_cycle_setting;
 

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -965,6 +965,9 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info, Vdp2* lines, Vdp2* re
       else
          info->LoadLineParams(info, j, lines);
 
+      if (!info->enable)
+         continue;
+
       for (i = 0; i < vdp2width; i++)
       {
          u32 color, dot;
@@ -1467,6 +1470,7 @@ static void LoadLineParamsNBG0(vdp2draw_struct * info, int line, Vdp2* lines)
    if (regs == NULL) return;
    ReadVdp2ColorOffset(regs, info, 0x1, 0x1);
    info->specialprimode = regs->SFPRMD & 0x3;
+   info->enable = regs->BGON & 0x1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1548,9 +1552,6 @@ static void Vdp2DrawNBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
       info.coordincy = (regs->ZMYN0.all & 0x7FF00) / (float) 65536;
       info.PlaneAddr = (void FASTCALL(*)(void *, int, Vdp2*))&Vdp2NBG0PlaneAddr;
    }
-   else
-      // Not enabled
-      return;
 
    info.transparencyenable = !(regs->BGON & 0x100);
    info.specialprimode = regs->SFPRMD & 0x3;
@@ -1618,6 +1619,7 @@ static void LoadLineParamsNBG1(vdp2draw_struct * info, int line, Vdp2* lines)
    if (regs == NULL) return;
    ReadVdp2ColorOffset(regs, info, 0x2, 0x2);
    info->specialprimode = (regs->SFPRMD >> 2) & 0x3;
+   info->enable = regs->BGON & 0x2;//f1 challenge map when zoomed out
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1683,7 +1685,7 @@ static void Vdp2DrawNBG1(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
    info.priority = (regs->PRINA >> 8) & 0x7;
    info.PlaneAddr = (void FASTCALL(*)(void *, int, Vdp2*))&Vdp2NBG1PlaneAddr;
 
-   if (!(info.enable & Vdp2External.disptoggle) ||
+   if (!(Vdp2External.disptoggle) ||
        (regs->BGON & 0x1 && (regs->CHCTLA & 0x70) >> 4 == 4)) // If NBG0 16M mode is enabled, don't draw
       return;
 
@@ -1722,6 +1724,7 @@ static void LoadLineParamsNBG2(vdp2draw_struct * info, int line, Vdp2* lines)
    if (regs == NULL) return;
    ReadVdp2ColorOffset(regs, info, 0x4, 0x4);
    info->specialprimode = (regs->SFPRMD >> 4) & 0x3;
+   info->enable = regs->BGON & 0x4;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1767,7 +1770,7 @@ static void Vdp2DrawNBG2(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
    info.priority = regs->PRINB & 0x7;
    info.PlaneAddr = (void FASTCALL(*)(void *, int, Vdp2*))&Vdp2NBG2PlaneAddr;
 
-   if (!(info.enable & Vdp2External.disptoggle) ||
+   if (!(Vdp2External.disptoggle) ||
       (regs->BGON & 0x1 && (regs->CHCTLA & 0x70) >> 4 >= 2)) // If NBG0 2048/32786/16M mode is enabled, don't draw
       return;
 
@@ -1792,6 +1795,7 @@ static void LoadLineParamsNBG3(vdp2draw_struct * info, int line, Vdp2* lines)
    if (regs == NULL) return;
    ReadVdp2ColorOffset(regs, info, 0x8, 0x8);
    info->specialprimode = (regs->SFPRMD >> 6) & 0x3;
+   info->enable = regs->BGON & 0x8;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1838,7 +1842,7 @@ static void Vdp2DrawNBG3(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
    info.priority = (regs->PRINB >> 8) & 0x7;
    info.PlaneAddr = (void FASTCALL(*)(void *, int, Vdp2*))&Vdp2NBG3PlaneAddr;
 
-   if (!(info.enable & Vdp2External.disptoggle) ||
+   if (!(Vdp2External.disptoggle) ||
       (regs->BGON & 0x1 && (regs->CHCTLA & 0x70) >> 4 == 4) || // If NBG0 16M mode is enabled, don't draw
       (regs->BGON & 0x2 && (regs->CHCTLA & 0x3000) >> 12 >= 2)) // If NBG1 2048/32786 is enabled, don't draw
       return;

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -100,6 +100,7 @@ void VIDSoftGetGlSize(int *width, int *height);
 void VIDSoftVdp1SwapFrameBuffer(void);
 void VIDSoftVdp1EraseFrameBuffer(Vdp1* regs, u8 * back_framebuffer);
 void VidsoftDrawSprite(Vdp2 * vdp2_regs, u8 * sprite_window_mask, u8* vdp1_front_framebuffer, u8 * vdp2_ram, Vdp1* vdp1_regs, Vdp2* vdp2_lines, u8*color_ram);
+void VIDSoftGetNativeResolution(int *width, int *height, int*interlace);
 
 VideoInterface_struct VIDSoft = {
 VIDCORE_SOFT,
@@ -131,6 +132,7 @@ VIDSoftVdp2DrawStart,
 VIDSoftVdp2DrawEnd,
 VIDSoftVdp2DrawScreens,
 VIDSoftGetGlSize,
+VIDSoftGetNativeResolution
 };
 
 pixel_t *dispbuffer=NULL;
@@ -1530,7 +1532,7 @@ static void LoadLineParamsNBG0(vdp2draw_struct * info, screeninfo_struct * sinfo
    if (regs == NULL) return;
    ReadVdp2ColorOffset(regs, info, 0x1, 0x1);
    info->specialprimode = regs->SFPRMD & 0x3;
-   info->enable = regs->BGON & 0x1;
+   info->enable = regs->BGON & 0x1 || regs->BGON & 0x20;//nbg0 or rbg1
    GeneratePlaneAddrTable(info, sinfo->planetbl, info->PlaneAddr, regs);//sonic 2, 2 player mode
 }
 
@@ -4157,4 +4159,11 @@ void VIDSoftGetGlSize(int *width, int *height)
    *width = vdp2width;
    *height = vdp2height;
 #endif
+}
+
+void VIDSoftGetNativeResolution(int *width, int *height, int* interlace)
+{
+   *width = vdp2width;
+   *height = vdp2height;
+   *interlace = vdp2_interlace;
 }

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -456,10 +456,12 @@ static INLINE int TestWindow(int wctl, int enablemask, int inoutmask, clipping_s
 int TestSpriteWindow(int wctl, int x, int y)
 {
    int mask;
+   int addr = (y*vdp2width) + x;
 
-   if ((y >= 512) || (x >= 704)) return 0;
+   if (addr >= (704 * 512))
+      return 0;
 
-   mask = sprite_window_mask[(y*vdp1width) + x];
+   mask = sprite_window_mask[addr];
 
    if (wctl & 0x20)//sprite window enabled on layer
    {
@@ -3742,7 +3744,7 @@ void VidsoftDrawSprite(Vdp2 * vdp2_regs, u8 * spr_window_mask, u8* vdp1_front_fr
                   if (spi.msbshadow)
                   {
                      if (sprite_window_enabled) {
-                        spr_window_mask[(y*vdp1width) + x] = 1;
+                        spr_window_mask[(y*vdp2width) + x] = 1;
                         info.titan_shadow_type = TITAN_MSB_SHADOW;
                      }
                      else

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -2486,7 +2486,7 @@ static int getpixel(int linenumber, int currentlineindex, vdp1cmd_struct *cmd, u
 			if(isTextured && endcodesEnabled && currentPixel == endcode)
 				return 1;
 			if (!((currentPixel == 0) && !SPD))
-				currentPixel = colorbank | currentPixel;
+				currentPixel = (colorbank &0xfff0)| currentPixel;
 			currentPixelIsVisible = 0xf;
 			break;
 
@@ -2513,7 +2513,7 @@ static int getpixel(int linenumber, int currentlineindex, vdp1cmd_struct *cmd, u
 				currentPixel = 0;
 		//		return 1;
 			if (!((currentPixel == 0) && !SPD))
-				currentPixel = colorbank | currentPixel;
+				currentPixel = (colorbank&0xffc0) | currentPixel;
 			currentPixelIsVisible = 0x3f;
 			break;
 		case 0x3://128 color
@@ -2522,7 +2522,7 @@ static int getpixel(int linenumber, int currentlineindex, vdp1cmd_struct *cmd, u
 			if(isTextured && endcodesEnabled && currentPixel == endcode)
 				return 1;
 			if (!((currentPixel == 0) && !SPD))
-				currentPixel = colorbank | currentPixel;
+				currentPixel = (colorbank&0xff80) | currentPixel;//dead or alive needs colorbank to be masked
 			currentPixelIsVisible = 0x7f;
 			break;
 		case 0x4://256 color
@@ -2532,7 +2532,7 @@ static int getpixel(int linenumber, int currentlineindex, vdp1cmd_struct *cmd, u
 				return 1;
 			currentPixelIsVisible = 0xff;
 			if (!((currentPixel == 0) && !SPD))
-				currentPixel = colorbank | currentPixel;
+				currentPixel = (colorbank&0xff00) | currentPixel;
 			break;
 		case 0x5://16bpp bank
 			endcode = 0x7fff;

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -137,7 +137,7 @@ pixel_t *dispbuffer=NULL;
 u8 *vdp1framebuffer[2]= { NULL, NULL };
 u8 *vdp1frontframebuffer;
 u8 *vdp1backframebuffer;
-u8 sprite_window_mask[512 * 256];
+u8 sprite_window_mask[704 * 512];
 
 static int vdp1width;
 static int vdp1height;
@@ -455,7 +455,7 @@ int TestSpriteWindow(int wctl, int x, int y)
 {
    int mask;
 
-   if ((y > 256) || (x > 512)) return 0;
+   if ((y >= 512) || (x >= 704)) return 0;
 
    mask = sprite_window_mask[(y*vdp1width) + x];
 
@@ -2580,7 +2580,7 @@ static int CheckDil(int y, Vdp1 * regs)
    return 0;
 }
 
-INLINE int IsUserClipped(int x, int y, Vdp1* regs)
+static INLINE int IsUserClipped(int x, int y, Vdp1* regs)
 {
    return !(x >= regs->userclipX1 &&
       x <= regs->userclipX2 &&
@@ -2588,7 +2588,7 @@ INLINE int IsUserClipped(int x, int y, Vdp1* regs)
       y <= regs->userclipY2);
 }
 
-INLINE int IsSystemClipped(int x, int y, Vdp1* regs)
+static INLINE int IsSystemClipped(int x, int y, Vdp1* regs)
 {
    return !(x >= 0 &&
       x <= regs->systemclipX2 &&
@@ -3467,7 +3467,7 @@ void VidsoftDrawSprite(Vdp2 * vdp2_regs, u8 * spr_window_mask, u8* vdp1_front_fr
 
    if (sprite_window_enabled)
    {
-      memset(spr_window_mask, 0, 512 * 256);
+      memset(spr_window_mask, 0, 704 * 512);
    }
 
    // Figure out whether to draw vdp1 framebuffer or vdp2 framebuffer pixels

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -71,8 +71,6 @@ static INLINE u32 COLSATSTRIPPRIORITY(u32 pixel) { return (0xFF000000 | pixel); 
 				(l & 0xFF000000)
 #endif
 
-static void PushUserClipping(int mode, Vdp1* regs);
-static void PopUserClipping(Vdp1* regs);
 
 int VIDSoftInit(void);
 void VIDSoftSetupGL(void);
@@ -144,10 +142,6 @@ u8 sprite_window_mask[512 * 256];
 static int vdp1width;
 static int vdp1height;
 static int vdp1interlace;
-static int vdp1clipxstart;
-static int vdp1clipxend;
-static int vdp1clipystart;
-static int vdp1clipyend;
 static int vdp1pixelsize;
 int vdp2width;
 int rbg0width = 0;
@@ -2288,10 +2282,10 @@ int VIDSoftIsFullscreen(void) {
 
 int VIDSoftVdp1Reset(void)
 {
-   vdp1clipxstart = 0;
-   vdp1clipxend = 512;
-   vdp1clipystart = 0;
-   vdp1clipyend = 256;
+   Vdp1Regs->userclipX1 = Vdp1Regs->systemclipX1 = 0;
+   Vdp1Regs->userclipY1 = Vdp1Regs->systemclipY1 = 0;
+   Vdp1Regs->userclipX2 = Vdp1Regs->systemclipX2 = 512;
+   Vdp1Regs->userclipY2 = Vdp1Regs->systemclipY2 = 256;
 
    return 0;
 }
@@ -2331,15 +2325,10 @@ void VIDSoftVdp1DrawStartBody(Vdp1* regs, u8 * back_framebuffer)
 
    VIDSoftVdp1EraseFrameBuffer(regs, back_framebuffer);
 
-   vdp1clipxstart = regs->userclipX1 = regs->systemclipX1 = 0;
-   vdp1clipystart = regs->userclipY1 = regs->systemclipY1 = 0;
    //night warriors doesn't set clipping most frames and uses
    //the last part of the vdp1 framebuffer as scratch ram
    //the previously set clipping values need to be reused
-   vdp1clipxend = regs->userclipX2 = regs->systemclipX2;
-   vdp1clipyend = regs->userclipY2 = regs->systemclipY2;
 }
-
 //////////////////////////////////////////////////////////////////////////////
 
 void VIDSoftVdp1DrawStart()
@@ -2591,6 +2580,39 @@ static int CheckDil(int y, Vdp1 * regs)
    return 0;
 }
 
+INLINE int IsUserClipped(int x, int y, Vdp1* regs)
+{
+   return !(x >= regs->userclipX1 &&
+      x <= regs->userclipX2 &&
+      y >= regs->userclipY1 &&
+      y <= regs->userclipY2);
+}
+
+INLINE int IsSystemClipped(int x, int y, Vdp1* regs)
+{
+   return !(x >= 0 &&
+      x <= regs->systemclipX2 &&
+      y >= 0 &&
+      y <= regs->systemclipY2);
+}
+
+int IsClipped(int x, int y, Vdp1* regs, vdp1cmd_struct * cmd)
+{
+   if (cmd->CMDPMOD & 0x0400)//user clipping enabled
+   {
+      int is_user_clipped = IsUserClipped(x, y, regs);
+
+      if (((cmd->CMDPMOD >> 9) & 0x3) == 0x3)//outside clipping mode
+         is_user_clipped = !is_user_clipped;
+
+      return is_user_clipped || IsSystemClipped(x, y, regs);
+   }
+   else
+   {
+      return IsSystemClipped(x, y, regs);
+   }
+}
+
 static void putpixel8(int x, int y, Vdp1 * regs, vdp1cmd_struct *cmd, u8 * back_framebuffer) {
 
     int y2 = y / vdp1interlace;
@@ -2606,24 +2628,12 @@ static void putpixel8(int x, int y, Vdp1 * regs, vdp1cmd_struct *cmd, u8 * back_
 
     currentPixel &= 0xFF;
 
-    if(mesh && ((x ^ y2) & 1)) {
-        return;
+    if (mesh && ((x ^ y2) & 1)) {
+       return;
     }
 
-    {
-        int clipped;
-
-        if (cmd->CMDPMOD & 0x0400) PushUserClipping((cmd->CMDPMOD >> 9) & 0x1, regs);
-
-        clipped = ! (x >= vdp1clipxstart &&
-            x < vdp1clipxend &&
-            y2 >= vdp1clipystart &&
-            y2 < vdp1clipyend);
-
-        if (cmd->CMDPMOD & 0x0400) PopUserClipping(regs);
-
-        if (clipped) return;
-    }
+    if (IsClipped(x, y, regs, cmd))
+       return;
 
     if ( SPD || (currentPixel & currentPixelIsVisible))
     {
@@ -2643,6 +2653,7 @@ static void putpixel(int x, int y, Vdp1* regs, vdp1cmd_struct * cmd, u8 * back_f
 	u16* iPix;
 	int mesh = cmd->CMDPMOD & 0x0100;
 	int SPD = ((cmd->CMDPMOD & 0x40) != 0);//show the actual color of transparent pixels if 1 (they won't be drawn transparent)
+   int original_y = y;
 
    if (CheckDil(y, regs))
       return;
@@ -2656,33 +2667,8 @@ static void putpixel(int x, int y, Vdp1* regs, vdp1cmd_struct * cmd, u8 * back_f
 	if(mesh && (x^y)&1)
 		return;
 
-	{
-		int clipped;
-
-		if (cmd->CMDPMOD & 0x0400) PushUserClipping((cmd->CMDPMOD >> 9) & 0x1, regs);
-
-		clipped = ! (x >= vdp1clipxstart &&
-			x < vdp1clipxend &&
-			y >= vdp1clipystart &&
-			y < vdp1clipyend);
-
-      //vdp1_clip_test in yabauseut
-      if (((cmd->CMDPMOD >> 9) & 0x3) == 0x3)//outside clipping mode
-      {
-         //don't display inside the box
-         if (regs->userclipX1 <= x &&
-            x <= regs->userclipX2 &&
-            regs->userclipY1 <= y &&
-            y <= regs->userclipY2)
-         {
-            clipped = 1;
-         }
-      }
-
-		if (cmd->CMDPMOD & 0x0400) PopUserClipping(regs);
-
-		if (clipped) return;
-	}
+   if (IsClipped(x, original_y, regs, cmd))
+      return;
 
 	if (cmd->CMDPMOD & (1 << 15))
 	{
@@ -3336,81 +3322,6 @@ void VIDSoftVdp1UserClipping(u8* ram, Vdp1*regs)
    regs->userclipY1 = T1ReadWord(ram, regs->addr + 0xE);
    regs->userclipX2 = T1ReadWord(ram, regs->addr + 0x14);
    regs->userclipY2 = T1ReadWord(ram, regs->addr + 0x16);
-
-#if 0
-   vdp1clipxstart = regs->userclipX1;
-   vdp1clipxend = regs->userclipX2;
-   vdp1clipystart = regs->userclipY1;
-   vdp1clipyend = regs->userclipY2;
-
-   // This needs work
-   if (vdp1clipxstart > regs->systemclipX1)
-      vdp1clipxstart = regs->userclipX1;
-   else
-      vdp1clipxstart = regs->systemclipX1;
-
-   if (vdp1clipxend < regs->systemclipX2)
-      vdp1clipxend = regs->userclipX2;
-   else
-      vdp1clipxend = regs->systemclipX2;
-
-   if (vdp1clipystart > regs->systemclipY1)
-      vdp1clipystart = regs->userclipY1;
-   else
-      vdp1clipystart = regs->systemclipY1;
-
-   if (vdp1clipyend < regs->systemclipY2)
-      vdp1clipyend = regs->userclipY2;
-   else
-      vdp1clipyend = regs->systemclipY2;
-#endif
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-static void PushUserClipping(int mode, Vdp1 * regs)
-{
-   if (mode == 1)
-   {
-      VDP1LOG("User clipping mode 1 not implemented\n");
-      return;
-   }
-
-   vdp1clipxstart = regs->userclipX1;
-   vdp1clipxend = regs->userclipX2;
-   vdp1clipystart = regs->userclipY1;
-   vdp1clipyend = regs->userclipY2;
-
-   // This needs work
-   if (vdp1clipxstart > regs->systemclipX1)
-      vdp1clipxstart = regs->userclipX1;
-   else
-      vdp1clipxstart = regs->systemclipX1;
-
-   if (vdp1clipxend < regs->systemclipX2)
-      vdp1clipxend = regs->userclipX2;
-   else
-      vdp1clipxend = regs->systemclipX2;
-
-   if (vdp1clipystart > regs->systemclipY1)
-      vdp1clipystart = regs->userclipY1;
-   else
-      vdp1clipystart = regs->systemclipY1;
-
-   if (vdp1clipyend < regs->systemclipY2)
-      vdp1clipyend = regs->userclipY2;
-   else
-      vdp1clipyend = regs->systemclipY2;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-static void PopUserClipping(Vdp1* regs)
-{
-   vdp1clipxstart = regs->systemclipX1;
-   vdp1clipxend = regs->systemclipX2;
-   vdp1clipystart = regs->systemclipY1;
-   vdp1clipyend = regs->systemclipY2;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -3421,11 +3332,6 @@ void VIDSoftVdp1SystemClipping(u8* ram, Vdp1*regs)
    regs->systemclipY1 = 0;
    regs->systemclipX2 = T1ReadWord(ram, regs->addr + 0x14);
    regs->systemclipY2 = T1ReadWord(ram, regs->addr + 0x16);
-
-   vdp1clipxstart = regs->systemclipX1;
-   vdp1clipxend = regs->systemclipX2;
-   vdp1clipystart = regs->systemclipY1;
-   vdp1clipyend = regs->systemclipY2;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -1095,6 +1095,33 @@ void Rbg0PutPixel(vdp2draw_struct *info, u32 color, u32 dot, int i, int j)
 
 //////////////////////////////////////////////////////////////////////////////
 
+int CheckBanks(Vdp2* regs, int compare_value)
+{
+   if (((regs->RAMCTL >> 0) & 3) == compare_value)//a0
+      return 0;
+   if (((regs->RAMCTL >> 2) & 3) == compare_value)//a1
+      return 0;
+   if (((regs->RAMCTL >> 4) & 3) == compare_value)//b0
+      return 0;
+   if (((regs->RAMCTL >> 6) & 3) == compare_value)//b1
+      return 0;
+
+   return 1;//no setting present
+}
+
+int Rbg0CheckRam(Vdp2* regs)
+{
+   if (((regs->RAMCTL >> 8) & 3) == 3)//both banks are divided
+   {
+      //ignore delta kax if the coefficient table
+      //bank is unspecified
+      if (CheckBanks(regs, 1))
+         return 1;
+   }
+
+   return 0;
+}
+
 static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparameterfp_struct *parameter, Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    int i, j;
@@ -1219,6 +1246,19 @@ static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparam
          SetupScreenVars(info, &sinfo2, p2->PlaneAddr, regs);
          coefx2 = coefy2 = 0;
          rcoefx2 = rcoefy2 = 0;
+      }
+
+      if (Rbg0CheckRam(regs))//sonic r / all star baseball 97
+      {
+         if (p->coefenab && p->coefmode == 0)
+         {
+            p->deltaKAx = 0;
+         }
+
+         if (p2 && p2->coefenab && p2->coefmode == 0)
+         {
+            p2->deltaKAx = 0;
+         }
       }
 
       if (info->linescreen)

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -812,7 +812,7 @@ void Vdp2GetInterlaceInfo(int * start_line, int * line_increment)
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info, Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info, Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    int i, j;
    int x, y;
@@ -830,6 +830,7 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info, Vdp2* lines, Vdp2* re
    u32 linescrollx_table[512] = { 0 };
    u32 linescrolly_table[512] = { 0 };
    float lineszoom_table[512] = { 0 };
+   int num_vertical_cell_scroll_enabled = 0;
 
    SetupScreenVars(info, &sinfo, info->PlaneAddr, regs);
 
@@ -862,6 +863,11 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info, Vdp2* lines, Vdp2* re
    }
 
    Vdp2GetInterlaceInfo(&start_line, &line_increment);
+
+   if (regs->SCRCTL & 1)
+      num_vertical_cell_scroll_enabled++;
+   if (regs->SCRCTL & 0x100)
+      num_vertical_cell_scroll_enabled++;
 
    //pre-generate line scroll tables
    for (j = start_line; j < vdp2height; j++)
@@ -948,16 +954,36 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info, Vdp2* lines, Vdp2* re
          // info->verticalscrolltbl should be incremented by info->verticalscrollinc
          // each time there's a cell change and reseted at the end of the line...
          // or something like that :)
-         y += T1ReadLong(ram, info->verticalscrolltbl) >> 16;
+         u32 scroll_value = 0;
+         int y_value = 0;
+
+         if (vdp2_interlace)
+            y_value = j / 2;
+         else
+            y_value = j;
+
+         if (num_vertical_cell_scroll_enabled == 1)
+         {
+            scroll_value = cell_data[y_value].data[0] >> 16;
+         }
+         else
+         {
+            if (info->titan_which_layer == TITAN_NBG0)
+               scroll_value = cell_data[y_value].data[0] >> 16;//reload cell data per line for sonic 2, 2 player mode
+            else if (info->titan_which_layer == TITAN_NBG1)
+               scroll_value = cell_data[y_value].data[1] >> 16;
+         }
+
+         y += scroll_value;
          y &= 0x1FF;
       }
 
       Y=y;
 
       if (vdp2_interlace)
-         info->LoadLineParams(info, j / 2, lines);
+         info->LoadLineParams(info, &sinfo, j / 2, lines);
       else
-         info->LoadLineParams(info, j, lines);
+         info->LoadLineParams(info, &sinfo, j, lines);
 
       if (!info->enable)
          continue;
@@ -1069,7 +1095,7 @@ void Rbg0PutPixel(vdp2draw_struct *info, u32 color, u32 dot, int i, int j)
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparameterfp_struct *parameter, Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparameterfp_struct *parameter, Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    int i, j;
    int x, y;
@@ -1110,7 +1136,7 @@ static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparam
 
          for (j = 0; j < vdp2height; j++)
          {
-            info->LoadLineParams(info, j, lines);
+            info->LoadLineParams(info, &sinfo, j, lines);
             ReadLineWindowClip(info->islinewindow, clip, &linewnd0addr, &linewnd1addr, ram, regs);
 
             for (i = 0; i < rbg0width; i++)
@@ -1234,7 +1260,7 @@ static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparam
             TitanPutLineHLine(info->linescreen, j, COLSAT2YAB32(0x3F, lineColor));
          }
 
-         info->LoadLineParams(info, j, lines);
+         info->LoadLineParams(info, &sinfo, j, lines);
          ReadLineWindowClip(info->islinewindow, clip, &linewnd0addr, &linewnd1addr, ram, regs);
 
          if (userpwindow)
@@ -1359,7 +1385,7 @@ static void FASTCALL Vdp2DrawRotationFP(vdp2draw_struct *info, vdp2rotationparam
       return;
    }
 
-   Vdp2DrawScroll(info, lines, regs, ram, color_ram);
+   Vdp2DrawScroll(info, lines, regs, ram, color_ram, cell_data);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1456,7 +1482,7 @@ static void Vdp2DrawLineScreen(void)
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void LoadLineParamsNBG0(vdp2draw_struct * info, int line, Vdp2* lines)
+static void LoadLineParamsNBG0(vdp2draw_struct * info, screeninfo_struct * sinfo, int line, Vdp2* lines)
 {
    Vdp2 * regs;
 
@@ -1465,11 +1491,12 @@ static void LoadLineParamsNBG0(vdp2draw_struct * info, int line, Vdp2* lines)
    ReadVdp2ColorOffset(regs, info, 0x1, 0x1);
    info->specialprimode = regs->SFPRMD & 0x3;
    info->enable = regs->BGON & 0x1;
+   GeneratePlaneAddrTable(info, sinfo->planetbl, info->PlaneAddr, regs);//sonic 2, 2 player mode
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void Vdp2DrawNBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void Vdp2DrawNBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    vdp2draw_struct info = { 0 };
    vdp2rotationparameterfp_struct parameter[2];
@@ -1589,23 +1616,23 @@ static void Vdp2DrawNBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
       info.isverticalscroll = 0;
    info.wctl = regs->WCTLA;
 
-   info.LoadLineParams = (void (*)(void *, int ,Vdp2*)) LoadLineParamsNBG0;
+   info.LoadLineParams = (void (*)(void *, void *,int ,Vdp2*)) LoadLineParamsNBG0;
 
    if (info.enable == 1)
    {
       // NBG0 draw
-      Vdp2DrawScroll(&info, lines, regs, ram, color_ram);
+      Vdp2DrawScroll(&info, lines, regs, ram, color_ram, cell_data);
    }
    else
    {
       // RBG1 draw
-      Vdp2DrawRotationFP(&info, parameter, lines, regs, ram, color_ram);
+      Vdp2DrawRotationFP(&info, parameter, lines, regs, ram, color_ram, cell_data);
    }
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void LoadLineParamsNBG1(vdp2draw_struct * info, int line, Vdp2* lines)
+static void LoadLineParamsNBG1(vdp2draw_struct * info, screeninfo_struct * sinfo, int line, Vdp2* lines)
 {
    Vdp2 * regs;
 
@@ -1614,11 +1641,12 @@ static void LoadLineParamsNBG1(vdp2draw_struct * info, int line, Vdp2* lines)
    ReadVdp2ColorOffset(regs, info, 0x2, 0x2);
    info->specialprimode = (regs->SFPRMD >> 2) & 0x3;
    info->enable = regs->BGON & 0x2;//f1 challenge map when zoomed out
+   GeneratePlaneAddrTable(info, sinfo->planetbl, info->PlaneAddr, regs);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void Vdp2DrawNBG1(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void Vdp2DrawNBG1(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    vdp2draw_struct info = { 0 };
 
@@ -1703,14 +1731,14 @@ static void Vdp2DrawNBG1(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
       info.isverticalscroll = 0;
    info.wctl = regs->WCTLA >> 8;
 
-   info.LoadLineParams = (void(*)(void *, int, Vdp2*)) LoadLineParamsNBG1;
+   info.LoadLineParams = (void(*)(void *, void*, int, Vdp2*)) LoadLineParamsNBG1;
 
-   Vdp2DrawScroll(&info, lines, regs, ram, color_ram);
+   Vdp2DrawScroll(&info, lines, regs, ram, color_ram, cell_data);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void LoadLineParamsNBG2(vdp2draw_struct * info, int line, Vdp2* lines)
+static void LoadLineParamsNBG2(vdp2draw_struct * info, screeninfo_struct * sinfo, int line, Vdp2* lines)
 {
    Vdp2 * regs;
 
@@ -1719,11 +1747,12 @@ static void LoadLineParamsNBG2(vdp2draw_struct * info, int line, Vdp2* lines)
    ReadVdp2ColorOffset(regs, info, 0x4, 0x4);
    info->specialprimode = (regs->SFPRMD >> 4) & 0x3;
    info->enable = regs->BGON & 0x4;
+   GeneratePlaneAddrTable(info, sinfo->planetbl, info->PlaneAddr, regs);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void Vdp2DrawNBG2(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void Vdp2DrawNBG2(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    vdp2draw_struct info = { 0 };
 
@@ -1774,14 +1803,14 @@ static void Vdp2DrawNBG2(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
    info.wctl = regs->WCTLB;
    info.isbitmap = 0;
 
-   info.LoadLineParams = (void(*)(void *, int, Vdp2*)) LoadLineParamsNBG2;
+   info.LoadLineParams = (void(*)(void *,void*, int, Vdp2*)) LoadLineParamsNBG2;
 
-   Vdp2DrawScroll(&info, lines, regs, ram, color_ram);
+   Vdp2DrawScroll(&info, lines, regs, ram, color_ram, cell_data);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void LoadLineParamsNBG3(vdp2draw_struct * info, int line, Vdp2* lines)
+static void LoadLineParamsNBG3(vdp2draw_struct * info, screeninfo_struct * sinfo, int line, Vdp2* lines)
 {
    Vdp2 * regs;
 
@@ -1790,11 +1819,12 @@ static void LoadLineParamsNBG3(vdp2draw_struct * info, int line, Vdp2* lines)
    ReadVdp2ColorOffset(regs, info, 0x8, 0x8);
    info->specialprimode = (regs->SFPRMD >> 6) & 0x3;
    info->enable = regs->BGON & 0x8;
+   GeneratePlaneAddrTable(info, sinfo->planetbl, info->PlaneAddr, regs);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void Vdp2DrawNBG3(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void Vdp2DrawNBG3(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    vdp2draw_struct info = { 0 };
 
@@ -1847,14 +1877,14 @@ static void Vdp2DrawNBG3(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
    info.wctl = regs->WCTLB >> 8;
    info.isbitmap = 0;
 
-   info.LoadLineParams = (void(*)(void *, int, Vdp2*)) LoadLineParamsNBG3;
+   info.LoadLineParams = (void(*)(void *, void*, int, Vdp2*)) LoadLineParamsNBG3;
 
-   Vdp2DrawScroll(&info, lines, regs, ram, color_ram);
+   Vdp2DrawScroll(&info, lines, regs, ram, color_ram, cell_data);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void LoadLineParamsRBG0(vdp2draw_struct * info, int line, Vdp2* lines)
+static void LoadLineParamsRBG0(vdp2draw_struct * info, screeninfo_struct * sinfo, int line, Vdp2* lines)
 {
    Vdp2 * regs;
 
@@ -1866,7 +1896,7 @@ static void LoadLineParamsRBG0(vdp2draw_struct * info, int line, Vdp2* lines)
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void Vdp2DrawRBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
+static void Vdp2DrawRBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data)
 {
    vdp2draw_struct info = { 0 };
    vdp2rotationparameterfp_struct parameter[2];
@@ -1971,9 +2001,9 @@ static void Vdp2DrawRBG0(Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram)
    info.isverticalscroll = 0;
    info.wctl = regs->WCTLC;
 
-   info.LoadLineParams = (void(*)(void *, int, Vdp2*)) LoadLineParamsRBG0;
+   info.LoadLineParams = (void(*)(void *, void*, int, Vdp2*)) LoadLineParamsRBG0;
 
-   Vdp2DrawRotationFP(&info, parameter, lines, regs, ram, color_ram);
+   Vdp2DrawRotationFP(&info, parameter, lines, regs, ram, color_ram, cell_data);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1996,6 +2026,7 @@ struct {
    Vdp2 regs;
    u8 ram[0x80000];
    u8 color_ram[0x1000];
+   struct CellScrollData cell_scroll_data[270];
 }vidsoft_thread_context;
 
 #define DECLARE_THREAD(NAME, LAYER, FUNC) \
@@ -2006,7 +2037,7 @@ void NAME(void * data) \
       if (vidsoft_thread_context.need_draw[LAYER]) \
       { \
          vidsoft_thread_context.need_draw[LAYER] = 0; \
-         FUNC(vidsoft_thread_context.lines, &vidsoft_thread_context.regs, vidsoft_thread_context.ram, vidsoft_thread_context.color_ram); \
+         FUNC(vidsoft_thread_context.lines, &vidsoft_thread_context.regs, vidsoft_thread_context.ram, vidsoft_thread_context.color_ram, vidsoft_thread_context.cell_scroll_data); \
          vidsoft_thread_context.draw_finished[LAYER] = 1; \
       } \
       YabThreadSleep(); \
@@ -3800,7 +3831,7 @@ void VIDSoftVdp2DrawEnd(void)
 
 //////////////////////////////////////////////////////////////////////////////
 
-void VidsoftStartLayerThread(int * layer_priority, int * draw_priority_0, int * num_threads_dispatched, int which_layer, void(*layer_func) (Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram))
+void VidsoftStartLayerThread(int * layer_priority, int * draw_priority_0, int * num_threads_dispatched, int which_layer, void(*layer_func) (Vdp2* lines, Vdp2* regs, u8* ram, u8* color_ram, struct CellScrollData * cell_data))
 {
    if (layer_priority[which_layer] > 0 || draw_priority_0[which_layer])
    {
@@ -3813,7 +3844,7 @@ void VidsoftStartLayerThread(int * layer_priority, int * draw_priority_0, int * 
       }
       else
       {
-        (*layer_func) (Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+        (*layer_func) (Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
       }
    }
 }
@@ -3878,6 +3909,7 @@ void VIDSoftVdp2DrawScreens(void)
       memcpy(&vidsoft_thread_context.regs, Vdp2Regs, sizeof(Vdp2));
       memcpy(vidsoft_thread_context.ram, Vdp2Ram, 0x80000);
       memcpy(vidsoft_thread_context.color_ram, Vdp2ColorRam, 0x1000);
+      memcpy(vidsoft_thread_context.cell_scroll_data, cell_scroll_data, sizeof(struct CellScrollData) * 270);
    }
 
    //draw vdp2 sprite layer on a thread if sprite window is not enabled
@@ -3903,11 +3935,11 @@ void VIDSoftVdp2DrawScreens(void)
    }
    else
    {
-      Vdp2DrawNBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
-      Vdp2DrawNBG1(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
-      Vdp2DrawNBG2(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
-      Vdp2DrawNBG3(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
-      Vdp2DrawRBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+      Vdp2DrawNBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
+      Vdp2DrawNBG1(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
+      Vdp2DrawNBG2(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
+      Vdp2DrawNBG3(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
+      Vdp2DrawRBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
    }
 }
 
@@ -3920,19 +3952,19 @@ void VIDSoftVdp2DrawScreen(int screen)
    switch(screen)
    {
       case 0:
-         Vdp2DrawNBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+         Vdp2DrawNBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
          break;
       case 1:
-         Vdp2DrawNBG1(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+         Vdp2DrawNBG1(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
          break;
       case 2:
-         Vdp2DrawNBG2(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+         Vdp2DrawNBG2(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
          break;
       case 3:
-         Vdp2DrawNBG3(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+         Vdp2DrawNBG3(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
          break;
       case 4:
-         Vdp2DrawRBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam);
+         Vdp2DrawRBG0(Vdp2Lines, Vdp2Regs, Vdp2Ram, Vdp2ColorRam, cell_scroll_data);
          break;
    }
 }

--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -96,7 +96,7 @@ yabsys_struct yabsys;
 const char *bupfilename = NULL;
 u64 tickfreq;
 //todo this ought to be in scspdsp.c
-ScspDsp scsp_dsp;
+ScspDsp scsp_dsp = { 0 };
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -242,7 +242,7 @@ extern int vdp1cob;
 #define IS_ZERO(a) ( (a) < EPS && (a) > -EPS)
 
 // AXB = |A||B|sin
-INLINE float cross2d( float veca[2], float vecb[2] )
+static INLINE float cross2d( float veca[2], float vecb[2] )
 {
    return (veca[0]*vecb[1])-(vecb[0]*veca[1]);
 }
@@ -653,7 +653,7 @@ int YglGLInit(int width, int height) {
    glDisable(GL_DEPTH_TEST);
    glDepthFunc(GL_GEQUAL);
    glClearDepthf(0.0f);
-   
+
    glCullFace(GL_FRONT_AND_BACK);
    glDisable(GL_CULL_FACE);
    glDisable(GL_DITHER);
@@ -1049,7 +1049,7 @@ void YglQuadOffset(YglSprite * input, YglTexture * output, YglCache * c, int cx,
     prg = PG_LINECOLOR_INSERT;
   }
 
-  
+
 	program = YglGetProgram(input, prg);
 	if (program == NULL) return;
 
@@ -1116,8 +1116,8 @@ void YglQuadOffset(YglSprite * input, YglTexture * output, YglCache * c, int cx,
 		tmp[2].t = tmp[4].t = tmp[5].t = (float)(y + (cy + vHeight)) - ATLAS_BIAS;
 	}
 
-	c->x = x; 
-	c->y = y; 
+	c->x = x;
+	c->y = y;
 
 	tmp[0].q = 1.0f;
 	tmp[1].q = 1.0f;
@@ -1316,7 +1316,7 @@ int YglQuadGrowShading(YglSprite * input, YglTexture * output, float * colors,Yg
 /*
    float dx = input->vertices[4] - input->vertices[0];
    float dy = input->vertices[5] - input->vertices[1];
- 
+
    if (dx < 0.0 && dy < 0.0 ){
 	   pos[0] = input->vertices[2*1 + 0]; // 1
 	   pos[1] = input->vertices[2*1 + 1];
@@ -1332,7 +1332,7 @@ int YglQuadGrowShading(YglSprite * input, YglTexture * output, float * colors,Yg
 	   pos[11] = input->vertices[2 * 3 + 1];
    }
    else
-*/  
+*/
    {
 	   pos[0] = input->vertices[0];
 	   pos[1] = input->vertices[1];
@@ -1927,7 +1927,7 @@ void YglRenderVDP1(void) {
       {
          level->prg[j].setupUniform((void*)&level->prg[j]);
       }
-        
+
 		  if( level->prg[j].currentQuad != 0 )
 		  {
 				glUniformMatrix4fv(level->prg[j].mtxModelView, 1, GL_FALSE, (GLfloat*)&_Ygl->mtxModelView.m[0][0]);
@@ -1947,7 +1947,7 @@ void YglRenderVDP1(void) {
 
    }
    level->prgcurrent = 0;
-   
+
 #if 0
    if ( (((Vdp1Regs->TVMR & 0x08)==0) && ((Vdp1Regs->FBCR & 0x03)==0x03) )
 	)
@@ -1961,7 +1961,7 @@ void YglRenderVDP1(void) {
    }
 #endif
    if ((((Vdp1Regs->TVMR & 0x08) == 0) && ((Vdp1Regs->FBCR & 0x03) == 0x03)) ||
-	   ((Vdp1Regs->FBCR & 2) == 0) || 
+	   ((Vdp1Regs->FBCR & 2) == 0) ||
 	   Vdp1External.manualchange)
    {
 	   u32 current_drawframe = 0;
@@ -2226,7 +2226,7 @@ void YglRender(void) {
      glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
      YglTM->texture = NULL;
    }
-   
+
 #if 0 // Test
    ShaderDrawTest();
 #else
@@ -2279,7 +2279,7 @@ void YglRender(void) {
             }
 
             YglMatrixMultiply(&dmtx, &mtx, &_Ygl->mtxModelView);
-            
+
   		    if( level->prg[j].currentQuad != 0 )
 			    {
 #if 0

--- a/yabauseut/src/scsp.c
+++ b/yabauseut/src/scsp.c
@@ -35,11 +35,57 @@
 #define SCSPREG_MCIPD   (*(volatile u16 *)0x25B0042C)
 #define SCSPREG_MCIRE   (*(volatile u16 *)0x25B0042E)
 
+struct SlotRegs
+{
+   u8 kx;
+   u8 kb;
+   u8 sbctl;
+   u8 ssctl;
+   u8 lpctl;
+   u8 pcm8b;
+   u32 sa;
+   u16 lsa;
+   u16 lea;
+   u8 d2r;
+   u8 d1r;
+   u8 hold;
+   u8 ar;
+   u8 ls;
+   u8 krs;
+   u8 dl;
+   u8 rr;
+   u8 si;
+   u8 sd;
+   u16 tl;
+   u8 mdl;
+   u8 mdxsl;
+   u8 mdysl;
+   u8 oct;
+   u16 fns;
+   u8 re;
+   u8 lfof;
+   u8 plfows;
+   u8 plfos;
+   u8 alfows;
+   u8 alfos;
+   u8 isel;
+   u8 imxl;
+   u8 disdl;
+   u8 dipan;
+   u8 efsdl;
+   u8 efpan;
+};
+
 volatile u32 hblank_counter=0;
 
 int tinc=0;
 
 void scsp_interactive_test();
+
+void vdp1_setup(u32 vdp1_tile_address);
+void vdp1_print_str(int x, int y, int palette, u32 vdp1_tile_address, char* str);
+void load_font_8x8_to_vram_1bpp_to_4bpp(u32 tile_start_address, u32 ram_pointer);
+extern u8 sine_tbl[];
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -60,7 +106,7 @@ void scsp_test()
       choice = gui_do_menu(vdp1_menu, &test_disp_font, 0, 0, "SCSP Tests", MTYPE_CENTER, -1);
       if (choice == -1)
          break;
-   }   
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -91,15 +137,15 @@ void scsp_minimal_slot_init(int slotnum)
    // Setup slot
    *(volatile u32 *)(slot+0x00) = 0x10300000 | (info->ssctl << 23) | 0; // key off, normal loop, start address
    *(volatile u16 *)(slot+0x04) = 0x0000; // LSA
-   *(volatile u16 *)(slot+0x06) = 0x00FF; // LEA  
+   *(volatile u16 *)(slot+0x06) = 0x00FF; // LEA
    *(volatile u16 *)(slot+0x08) = (info->d2r << 11) | (info->d1r << 6) | (info->eghold << 5) | info->ar; // Normal D2R, D1R, EGHOLD, AR
    *(volatile u16 *)(slot+0x0A) = (info->lpslnk << 14) | (info->krs << 10) | (info->dl << 5) | info->rr; // Normal LPSLNK, KRS, DL, RR
-   *(volatile u16 *)(slot+0x0C) = (info->stwinh << 9) | (info->sdir << 8) | info->tl; // stwinh, sdir, tl    
+   *(volatile u16 *)(slot+0x0C) = (info->stwinh << 9) | (info->sdir << 8) | info->tl; // stwinh, sdir, tl
    *(volatile u16 *)(slot+0x0E) = (info->mdl << 12) | (info->mdxsl << 6) | info->mdysl; // modulation stuff
    *(volatile u16 *)(slot+0x10) = (info->oct << 11) | info->fns; // oct/fns
    *(volatile u16 *)(slot+0x12) = (info->lfof << 10) | (info->plfows << 8) | (info->plfos << 5) | (info->alfows << 3) | info->alfos; // lfo
    *(volatile u16 *)(slot+0x14) = (info->isel << 3) | info->imxl; // isel/imxl
-   *(volatile u16 *)(slot+0x16) = (info->disdl << 13) | (info->dipan << 8) | (info->efsdl << 5) | info->efpan; // 
+   *(volatile u16 *)(slot+0x16) = (info->disdl << 13) | (info->dipan << 8) | (info->efsdl << 5) | info->efpan; //
 
    // Time to key on
    *(volatile u8 *)(slot+0x00) = 0x18 | (info->ssctl >> 1);
@@ -489,7 +535,7 @@ void scsp_timer_timing_test(u16 timer_setting)
 {
    // Disable everything temporarily
    SCSPREG_SCIEB = 0;
-   SCSPREG_MCIEB = 0;   
+   SCSPREG_MCIEB = 0;
 
    tinc = timer_setting >> 8;
 
@@ -550,7 +596,7 @@ void scsp_timer_timing_test1()
 
 void scsp_timer_timing_test2()
 {
-   scsp_timer_timing_test(0x0200);                                         
+   scsp_timer_timing_test(0x0200);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -624,7 +670,7 @@ void scsp_int_on_timer_enable_test()
    bios_change_scu_interrupt_mask(~(0x40 | 0x4), 0);
 
    // Clear timer
-   SCSPREG_TIMERA = 0x0700; 
+   SCSPREG_TIMERA = 0x0700;
    SCSPREG_MCIRE = 0x40;
 
    // Wait until MCIPD is showing an interrupt pending
@@ -655,7 +701,7 @@ void scsp_int_on_timer_reset_test()
    bios_change_scu_interrupt_mask(~0x40, 0);
 
    // Enable timer
-   SCSPREG_TIMERA = 0x0700; 
+   SCSPREG_TIMERA = 0x0700;
    SCSPREG_MCIRE = 0x40;
    SCSPREG_MCIEB = 0x40;
 
@@ -693,7 +739,7 @@ void scsp_int_dup_test()
    bios_change_scu_interrupt_mask(~(0x40 | 0x4), 0);
 
    // Enable timer
-   SCSPREG_TIMERA = 0; 
+   SCSPREG_TIMERA = 0;
    SCSPREG_MCIRE = 0x40;
    SCSPREG_MCIEB = 0x40;
 
@@ -850,19 +896,28 @@ void scsp_dsp_clear()
 {
    volatile u16* sound_ram_ptr = (u16 *)0x25a00000;
    volatile u16* coef_ptr = (u16 *)0x25b00700;
-   volatile u16* mems_ptr = (u16 *)0x25b00C00;
-   volatile u16* temp_ptr = (u16 *)0x25b00E00;
+   volatile u16* madrs_ptr = (u16 *)0x25b00780;
+   volatile u16* temp_ptr = (u16 *)0x25b00C00;
+   volatile u16* mems_ptr = (u16 *)0x25b00E00;
+
    int i;
 
    scsp_dsp_erase_mpro();
 
-   for (i = 0; i < 27; i++)
-   {
+   for (i = 0; i < 0xffff; i++)
       sound_ram_ptr[i] = 0;
+
+   for (i = 0; i < 64; i++)
       mems_ptr[i] = 0;
-      temp_ptr[i] = 0;
+
+   for (i = 0; i < 64; i++)
       coef_ptr[i] = 0;
-   }
+
+   for (i = 0; i < 64; i++)
+      madrs_ptr[i] = 0;
+
+   for (i = 0; i < 256; i++)
+      temp_ptr[i] = 0;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -935,6 +990,64 @@ void scsp_dsp_start_test(u16 a_val, u16 b_val, int*yval)
    *yval = *yval + 1;
 }
 
+//convert float in ring buffer to 24 bit int and store it in mems
+void scsp_dsp_float_to_int_test(u16 test_val, int*yval)
+{
+   volatile u16* sound_ram_ptr = (u16 *)0x25a00000;//ring buffer
+   volatile u16* start_dsp = (u16 *)0x25b00BF0;
+
+   u16 instr1 = 0;
+   u16 instr2 = 0;
+   u16 instr3 = 0;
+
+   scsp_dsp_clear();
+
+   start_dsp[0] = 0;
+
+   int i;
+   for (i = 0; i < 0xffff; i++)
+      sound_ram_ptr[i] = test_val;
+
+   int instr_pos = 0;
+
+   scsp_dsp_write_mpro(0, 0, 0, 0, instr_pos++);//nop
+
+   //convert ring buffer value to float
+   //and put it in memval
+   instr2 = 1 << 13;//set mrd
+   instr2 |= 1 << 15;// set table
+   instr3 = 1 << 15; //set nofl
+
+   scsp_dsp_write_mpro(0, 0, instr2, instr3, instr_pos++);
+
+   scsp_dsp_write_mpro(0, 0, 0, 0, instr_pos++);//nop
+
+   scsp_dsp_write_mpro(0, 1 << 5 | 1, 1 << 13, 0, instr_pos++);//iwa = 1, iwt, mrd
+
+   //store memval in mems[0]
+   instr1 = 1 << 5;//set iwt
+
+   scsp_dsp_write_mpro(0, instr1, 0, 0, instr_pos++);
+
+   //start the dsp
+   start_dsp[0] = 1;
+
+   int q;
+
+   for(q = 0; q < 10; q++)
+      vdp_wait_hblankout();
+
+   vdp_printf(&test_disp_font, 0 * 8, *yval * 8, 0, "NNNNNNNNNNNNNN");
+
+   volatile u16* mems_ptr = (u16 *)0x25b00E00;
+
+   u32 test_result = mems_ptr[2] | mems_ptr[3] << 8;
+
+   vdp_printf(&test_disp_font, 0 * 8, *yval * 8, 0xF, "0x%04x 0x%08x", test_val, test_result);
+   *yval = *yval + 1;
+
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 void scsp_dsp_multiply_test()
@@ -962,6 +1075,98 @@ void scsp_dsp_multiply_test()
    }
 }
 
+//convert all possible 16 bit floats and store them in vdp1 ram
+void scsp_dsp_generate_float_to_int_table()
+{
+   int i;
+   int yval = 0;
+   u16 test_val = 0;
+
+   volatile u16* control_ptr = (u16 *)0x25b00400;
+
+   control_ptr[1] = 0 << 7 | 0;
+
+   int write_results = 1;
+
+   if (write_results)//write results to vdp1 ram
+   {
+      volatile u32* dest = (u32 *)VDP1_RAM;
+      int i;
+
+      int pos = 1;
+
+      dest[0] = 0xdeadbeef;//for verifying byte order
+
+      //int increment = 1;
+
+      int start = 0;
+      int stop = 0xffff;
+
+      for (i = start; i < stop; i++)
+      {
+         yval = 0;
+         scsp_dsp_float_to_int_test(i, &yval);
+         volatile u16* mems_ptr = (u16 *)0x25b00E00;
+         u32 test_result = mems_ptr[2] | mems_ptr[3] << 8;
+         dest[pos++] = test_result;
+      }
+
+      dest[pos] = 0xdeadbeef;//end of list
+
+      vdp_printf(&test_disp_font, 24 * 8, 0 * 8, 0xF, "finished");
+
+      for (;;)
+      {
+         while (!(VDP2_REG_TVSTAT & 8))
+         {
+            ud_check(0);
+         }
+
+         if (per[0].but_push_once & PAD_START)
+         {
+            reset_system();
+         }
+      }
+   }
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         u32* dest = (u32 *)VDP2_RAM;
+
+         int q;
+         for (q = 0; q < 0x10000; q++)
+            dest[q] = 0;
+
+         scsp_dsp_float_to_int_test(test_val, &yval);
+         test_val += 0x1111;
+
+         volatile u16* mems_ptr = (u16 *)0x25b00E00;
+
+         volatile u16* sound_ram_ptr = (u16 *)0x25a00000;
+
+         for (i = 0; i < 28; i++)
+            vdp_printf(&test_disp_font, 8 * 8, i * 8, 0xF, "0x%04x", sound_ram_ptr[i]);
+
+         for (i = 0; i < 28; i++)
+            vdp_printf(&test_disp_font, 16 * 8, i * 8, 0xF, "0x%04x", mems_ptr[i]);
+
+         u32 test_result = mems_ptr[2] | mems_ptr[3] << 8;
+
+         vdp_printf(&test_disp_font, 24 * 8, 0 * 8, 0xF, "0x%08x", test_result);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+
 //////////////////////////////////////////////////////////////////////////////
 
 void scsp_dsp_test()
@@ -980,6 +1185,12 @@ u16 square_table[] =
    0x4000, 0x4000, 0x4000, 0x4000, 0x4000, 0x4000, 0x4000, 0x4000
 };
 
+u16 square_table8[] =
+{
+   0xc0, 0xc0, 0xc0, 0xc0, 0xc0, 0xc0, 0xc0, 0xc0,
+   0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40
+};
+
 #define KEYONEX 0x10000000
 #define KEYONB 0x08000000
 
@@ -989,7 +1200,7 @@ u16 fns_table[] = {
 
 //////////////////////////////////////////////////////////////////////////////
 
-void write_note(u8 which_slot, u32 sa, u16 lsa, u16 lea, u8 oct, u16 fns, u8 pcm8b, u8 loop)
+void write_note(u8 which_slot, u32 sa, u16 lsa, u16 lea, u8 oct, u16 fns, u8 pcm8b, u8 loop, u8 plfows, u8 plfos,u8 lfof, u8 ar)
 {
    volatile u16* slot_ptr = (u16 *)0x25b00000;
    volatile u32* slot_ptr_l = (u32 *)0x25b00000;
@@ -1002,34 +1213,135 @@ void write_note(u8 which_slot, u32 sa, u16 lsa, u16 lea, u8 oct, u16 fns, u8 pcm
    slot_ptr_l[which_slot*0x8] = KEYONEX | KEYONB | sa | (pcm8b << 20) | (loop << 21);
    slot_ptr[offset + 2] = lsa;//lsa
    slot_ptr[offset + 3] = lea;//lea
-   slot_ptr[offset + 4] = 0x001f;//d2r,d1r,ho,ar
+   slot_ptr[offset + 4] = 0x0000 | ar;//d2r,d1r,ho,ar
    slot_ptr[offset + 5] = 0x001f;//ls,krs,dl,rr
    slot_ptr[offset + 6] = 0x0000;//si,sd,tl
    slot_ptr[offset + 7] = 0x0000;//mdl,mdxsl,mdysl
    slot_ptr[offset + 8] = (oct << 11) | fns;//oct,fns
-   slot_ptr[offset + 9] = 0x0000;//re,lfof,plfows,plfos,alfows,alfos
+   slot_ptr[offset + 9] = (lfof << 10) | (plfows << 8) | (plfos << 5) | (0 << 3) | 0;//re,lfof,plfows,plfos,alfows,alfos
    slot_ptr[offset + 10] = 0x0000;//isel,imxl
    slot_ptr[offset + 11] = 0xE000;//disdl,dipan,efsdl,efpan
 }
 
+void write_note_struct(u8 which_slot, struct SlotRegs * regs)
+{
+   volatile u16* slot_ptr = (u16 *)0x25b00000;
+   volatile u32* slot_ptr_l = (u32 *)0x25b00000;
+
+   int offset = which_slot * 0x10;
+
+   //force a note off
+   slot_ptr_l[which_slot * 0x8] = KEYONEX;
+
+   slot_ptr_l[which_slot * 0x8] =
+      KEYONEX |
+      KEYONB |
+      (regs->sbctl << 25) |
+      (regs->ssctl << 23) |
+      (regs->lpctl << 21) |
+      (regs->pcm8b << 20) |
+      regs->sa;
+
+   slot_ptr[offset + 2] = regs->lsa;//lsa
+   slot_ptr[offset + 3] = regs->lea;//lea
+   slot_ptr[offset + 4] =
+      (regs->d2r << 11) |
+      (regs->d1r << 6) |
+      (regs->hold << 5) |
+      regs->ar;//d2r,d1r,ho,ar
+   slot_ptr[offset + 5] = (regs->ls << 14) | (regs->krs << 10) | (regs->dl << 5) | regs->rr;//ls,krs,dl,rr
+   slot_ptr[offset + 6] = (regs->si << 9) | (regs->sd << 8) | regs->tl;//si,sd,tl
+   slot_ptr[offset + 7] = (regs->mdl << 12) | (regs->mdxsl << 6) | regs->mdysl;//mdl,mdxsl,mdysl
+   slot_ptr[offset + 8] = (regs->oct << 11) | regs->fns;//oct,fns
+   slot_ptr[offset + 9] = (regs->re << 15) | (regs->lfof << 10) | (regs->plfows << 8) | (regs->plfos << 5) | (regs->alfows << 3) | regs->alfos;//re,lfof,plfows,plfos,alfows,alfos
+   slot_ptr[offset + 10] = 0x0000;//isel,imxl
+   slot_ptr[offset + 11] = (regs->disdl << 13);//disdl,dipan,efsdl,efpan
+}
+
+void all_note_off()
+{
+   volatile u32* slot_ptr_l = (u32 *)0x25b00000;
+
+   int which_slot = 0;
+   for(which_slot = 0; which_slot < 32; which_slot++)
+      slot_ptr_l[which_slot * 0x8] = KEYONEX; //force a note off
+}
+
 //////////////////////////////////////////////////////////////////////////////
+
+void scsp_setup(u32 base_addr)
+{
+   int i;
+
+   volatile u16* erase = (u16 *)(0x25a00000);
+
+   for (i = 0; i < 0x20000; i++)
+   {
+      erase[i] = 0;
+   }
+
+   volatile u16* sound_ram_ptr_16 = (u16 *)(0x25a00000 + base_addr);
+
+   for (i = 0; i < 16; i++)
+   {
+      sound_ram_ptr_16[i] = square_table[i];
+   }
+   int offset = 128;
+
+   volatile u8* su8 = (u8 *)(0x25a00000 + offset + base_addr);
+
+   for (i = 0; i < 16; i++)
+   {
+      su8[i] = square_table8[i];
+   }
+
+   volatile u16* control = (u16 *)0x25b00400;
+   control[0] = 7;//master vol
+
+   //write a long sample
+   volatile u16* sound_ram_ptr_16a = (u16 *)(0x25a00000 + base_addr + 256);
+
+   for (i = 0; i < 0xfff0; i++)
+   {
+      sound_ram_ptr_16a[i] = square_table[i&0xf];
+   }
+}
+
+void vdp1_setup(u32 vdp1_tile_address)
+{
+   load_font_8x8_to_vram_1bpp_to_4bpp(vdp1_tile_address, VDP1_RAM);
+   VDP1_REG_PTMR = 0x02;//draw automatically with frame change
+   VDP2_REG_PRISA = 7 | (6 << 8);
+   VDP2_REG_PRISB = 5 | (4 << 8);
+   VDP2_REG_PRISC = 3 | (2 << 8);
+   VDP2_REG_PRISD = 1 | (0 << 8);
+   VDP2_REG_SPCTL = (0 << 12) | (0 << 8) | (0 << 5) | 7;
+}
 
 void scsp_test_note_on()
 {
    volatile u32* slot_ptr_l = (u32 *)0x25b00000;
-   volatile u16* sound_ram_ptr = (u16 *)0x25a00000;
-   volatile u16* control = (u16 *)0x25b00400;
+
    int oct = 0xd;
    int which_note = 0;
    int major_scale[] = { 0,2,4,5,7,9,11 };
-   int i;
 
-   for (i = 0; i < 16; i++)
-   {
-      sound_ram_ptr[i] = square_table[i];
-   }
+   scsp_setup(0);
 
-   control[0] = 7;//master vol
+   write_note(0, 0, 0, 0x10 - 1, oct, 0x0, 0, 1,0,0,0,0x1f);
+
+   int oct_test = 0xd;
+
+   int lfof = 7;
+   int plfows = 2;
+   int plfos = 5;
+
+   int is_8_bit = 0;
+
+   if (!is_8_bit)
+      write_note(0, 0, 0, 0x10 - 1, oct_test & 0xf, 0, 0, 1, plfows, plfos, lfof,0x8);
+   else
+      write_note(0, 128, 0, 15, oct_test & 0xf, 0, 1, 1, plfows, plfos, lfof, 0x8);
 
    for (;;)
    {
@@ -1041,7 +1353,7 @@ void scsp_test_note_on()
       //key on
       if (per[0].but_push_once & PAD_A)
       {
-         write_note(0, 0, 0, 0x10 - 1, oct, fns, 0, 1);
+         write_note(0, 0, 0, 0x10 - 1, oct, fns, 0, 1, 0, 0, 0, 0x1f);
          which_note++;
          if (which_note > 6)
             which_note = 0;
@@ -1049,7 +1361,7 @@ void scsp_test_note_on()
 
       if (per[0].but_push_once & PAD_X)
       {
-         write_note(1, 0, 0, 0x10 - 1, oct, fns, 0, 1);
+         write_note(1, 0, 0, 0x10 - 1, oct, fns, 0, 1, 0, 0, 0, 0x1f);
          which_note++;
          if (which_note > 6)
             which_note = 0;
@@ -1059,6 +1371,854 @@ void scsp_test_note_on()
       if (per[0].but_push_once & PAD_B)
       {
          slot_ptr_l[0] = KEYONB;
+      }
+
+      if (per[0].but_push_once & PAD_Z)
+      {
+         oct_test++;
+         write_note(0, 0, 0, 0x10 - 1, oct_test & 0xf, fns, 0, 1, 0, 0, 0, 0x1f);
+
+      }
+
+      if (per[0].but_push_once & PAD_C)
+      {
+         oct_test--;
+         write_note(0, 0, 0, 0x10 - 1, oct_test & 0xf, fns, 0, 1, 0, 0, 0, 0x1f);
+      }
+
+      if (per[0].but_push_once & PAD_L)
+      {
+         plfows++;
+
+         if (plfows > 3)
+            plfows = 0;
+         write_note(0, 0, 0, 0x10 - 1, oct_test & 0xf, fns, 0, 1, plfows, plfos, lfof, 0x1f);
+      }
+
+      if (per[0].but_push_once & PAD_R)
+      {
+         lfof++;
+
+         if (lfof > 31)
+            lfof = 0;
+         write_note(0, 0, 0, 0x10 - 1, oct_test & 0xf, fns, 0, 1, plfows, plfos, lfof, 0x1f);
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         plfos++;
+
+         if (plfos > 7)
+            plfos = 0;
+         write_note(0, 0, 0, 0x10 - 1, oct_test & 0xf, fns, 0, 1, plfows, plfos, lfof, 0x1f);
+      }
+
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+//play note from different starting addresses
+void scsp_test_addrs()
+{
+   u32 addr = 0;
+
+   scsp_setup(addr);
+
+   write_note(0, addr + 128, 0, 0x10 - 1, 0xd, 0, 1, 1, 0, 0, 0, 0x1f);
+
+   for (;;)
+   {
+      vdp_vsync();
+      if (per[0].but_push_once & PAD_A)
+      {
+
+         addr += 0x100;
+         addr &= 0xfffff;
+
+         scsp_setup(addr);
+
+         write_note(0, addr + 128, 0, 0x10 - 1, 0xd & 0xf, 0, 1, 1, 0, 0, 0, 0x1f);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+//write key on to each channel
+void scsp_test_all_channels()
+{
+   u32 addr = 0;
+
+   scsp_setup(addr);
+
+   write_note(0, addr + 128, 0, 0x10 - 1, 0xd, 0, 1, 1, 0, 0, 0, 0x1f);
+
+   int channel = 0;
+
+   for (;;)
+   {
+      vdp_vsync();
+      if (per[0].but_push_once & PAD_A)
+      {
+         channel++;
+
+         all_note_off();
+
+         write_note(channel, addr + 128, 0, 0x10 - 1, 0xd & 0xf, 0, 1, 1, 0, 0, 0, 0x1f);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+void vdp1_boilerplate()
+{
+   vdp_start_draw_list();
+   sprite_struct quad = { 0 };
+
+   //system clipping
+   quad.x = 320;
+   quad.y = 224;
+
+   vdp_system_clipping(&quad);
+
+   //user clipping
+   quad.x = 0;
+   quad.y = 0;
+   quad.x2 = 320;
+   quad.y2 = 224;
+
+   vdp_user_clipping(&quad);
+
+   quad.x = 0;
+   quad.y = 0;
+
+   vdp_local_coordinate(&quad);
+}
+
+void print_regs(u32 which_slot, u32 vdp1_tile_address, u8 is_word)
+{
+   char str[128] = { 0 };
+
+   int i;
+
+   if (is_word)
+   {
+      volatile u16* slot_ptr = (u16 *)0x25b00000;
+
+      int offset = which_slot * 0x10;
+
+      for (i = 0; i < 16; i++)
+      {
+         u16 val = slot_ptr[offset + i];
+         sprintf(str, "%04x", val);
+         vdp1_print_str(0, i * 8, 4, vdp1_tile_address, str);
+      }
+   }
+   else
+   {
+      volatile u8* slot_ptr = (u8 *)0x25b00000;
+
+      int offset = which_slot * 0x20;
+
+      int j = 0;
+      for (i = 0; i < 32; i+=2)
+      {
+         u8 val = slot_ptr[offset + i];
+         sprintf(str, "%02x", val);
+         vdp1_print_str(0, j * 8, 4, vdp1_tile_address, str);
+         val = slot_ptr[offset + i + 1];
+         sprintf(str, "%02x", val);
+         vdp1_print_str(16, j * 8, 4, vdp1_tile_address, str);
+         j++;
+      }
+   }
+}
+
+void do_word_write(int which_slot, u16 value, u32 vdp1_tile_address)
+{
+   int i;
+
+   for (i = 0; i < 16; i++)
+   {
+      volatile u16* slot_ptr = (u16 *)0x25b00000;
+      int offset = which_slot * 0x10;
+
+      slot_ptr[i + offset] = value;
+   }
+   print_regs(which_slot, vdp1_tile_address, 1);
+}
+
+void do_byte_write(int which_slot, u8 value, u32 vdp1_tile_address)
+{
+   int i;
+
+   for (i = 0; i < 32; i++)
+   {
+      volatile u8* slot_ptr = (u8 *)0x25b00000;
+      int offset = which_slot * 0x20;
+
+      slot_ptr[i + offset] = value;
+   }
+   print_regs(which_slot, vdp1_tile_address, 0);
+}
+
+//write and read all the slot registers
+void scsp_slot_reg_write_read()
+{
+   const u32 vdp1_tile_address = 0x10000;
+
+   vdp1_setup(vdp1_tile_address);
+
+   int which_slot = 0;
+
+   u8 val = 0;
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      u16 write_val = val << 12 | val << 8 | val << 4 | val;
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         do_word_write(which_slot, write_val, vdp1_tile_address);
+         val++;
+      }
+      if (per[0].but_push_once & PAD_B)
+      {
+         do_byte_write(which_slot, write_val, vdp1_tile_address);
+         val++;
+      }
+
+      if (per[0].but_push_once & PAD_C)
+      {
+         which_slot++;
+      }
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+void display_registers(int slot, u32 vdp1_tile_address)
+{
+   char str[128] = { 0 };
+   int i;
+   volatile u16* control = (u16 *)(0x25b00400);
+
+   int x_coord = 5;
+
+   print_regs(slot, vdp1_tile_address, 1);
+
+   for (i = 0; i < 30; i++)
+   {
+      u16 var = control[i];
+      sprintf(str, "%04x ", var);
+      vdp1_print_str(x_coord * 8, i * 8, 4, vdp1_tile_address, str);
+   }
+
+   x_coord += 5;
+
+   for (i = 0; i < 32; i++)
+   {
+      volatile u16* stack = (u16 *)0x25b00600;
+      sprintf(str, "%04x", stack[0 + i]);
+      vdp1_print_str(x_coord * 8, i * 8, 4, vdp1_tile_address, str);
+      sprintf(str, "%04x", stack[32 + i]);
+      vdp1_print_str((x_coord+5) * 8, i * 8, 4, vdp1_tile_address, str);
+   }
+}
+
+//record envelope deltas
+void scsp_envelope_edit()
+{
+   u32 addr = 0;
+
+   const u32 vdp1_tile_address = 0x10000;
+
+   vdp1_setup(vdp1_tile_address);
+
+   scsp_setup(addr);
+
+   int i;
+
+   u32 max_snd_addr = 512;
+
+   volatile u16* max_snd_ptr = (u16 *)(0x25a00000 + max_snd_addr);
+
+   for (i = 0; i < 128; i++)
+      max_snd_ptr[i] = 0x7fff;
+
+   volatile u16* control = (u16 *)(0x25b00400);
+
+   int monitor = 0;
+
+   int menu_cursor = 0;
+
+   int values[8] = { 0 };
+
+   int initial_setting = 2;
+
+   if (initial_setting == 0)
+   {
+      values[0] = 0x1;//ar
+      values[5] = 0xf;//krs
+   }
+   else if (initial_setting == 1)
+   {
+      values[0] = 0xf;//ar
+      values[1] = 0xf;//d1r
+      values[2] = 0x0;//d2r
+      values[3] = 0x0;//rr
+      values[4] = 0x4;//dl
+      values[5] = 0xf;//krs
+   }
+   else if (initial_setting == 2)
+   {
+      values[0] = 0xf;//ar
+      values[1] = 0xf;//d1r
+      values[2] = 0xe;//d2r
+      values[3] = 0x0;//rr
+      values[4] = 0x4;//dl
+      values[5] = 0xf;//krs
+   }
+
+   char* value_names[] =
+   {
+      "ar",
+      "d1r",
+      "d2r",
+      "rr",
+      "dl",
+      "krs",
+      "ho"
+   };
+
+   struct ResultRecord
+   {
+      int frame;
+      int env_value;
+      int env_state;
+   };
+
+   struct ResultRecord results[512] = { { 0 } };
+   int result_record_pos = 0;
+
+   int test_active = 0;
+   int test_frame = 0;
+
+   int write_keyoff = 0;
+   int keyoff_timer = 0;
+   int keyoff_limit = 0;
+
+   int record_all = 0;
+
+   for (;;)
+   {
+      char str[128] = { 0 };
+
+      vdp_vsync();
+
+      if (write_keyoff)
+      {
+         if (keyoff_timer == keyoff_limit)
+         {
+            write_keyoff = 0;
+            keyoff_timer = 0;
+            volatile u8* slot_ptr = (u8 *)0x25b00000;
+            //execute keyoff
+            slot_ptr[0] = (1 << 4);
+         }
+         else
+             keyoff_timer++;
+      }
+
+      if (test_active)
+      {
+         u32 val1 = (control[4] & 0x1f) << 5;//upper 5 bits of internal eg value
+         u32 val2 = (control[4] >> 5) & 3;//current envelope state
+
+         if (record_all)
+         {
+            result_record_pos++;
+            results[result_record_pos].frame = test_frame;
+            results[result_record_pos].env_value = val1;
+            results[result_record_pos].env_state = val2;
+         }
+         else
+         {
+            //just record the differences
+            if (results[result_record_pos].env_value != val1 ||
+               results[result_record_pos].env_state != val2)
+            {
+               result_record_pos++;
+               results[result_record_pos].frame = test_frame;
+               results[result_record_pos].env_value = val1;
+               results[result_record_pos].env_state = val2;
+            }
+         }
+
+         if (result_record_pos > 28 || test_frame > (60*5))
+         {
+            test_active = 0;
+
+            int j;
+
+            //zero unused results
+            for (j = result_record_pos + 1; j < 28; j++)
+            {
+               results[j].frame = 0;
+               results[j].env_value = 0;
+               results[j].env_state = 0;
+            }
+         }
+
+         test_frame++;
+      }
+
+      control[4] = monitor << 11;
+
+      vdp1_boilerplate();
+
+      display_registers(monitor, vdp1_tile_address);
+
+      vdp1_print_str(20 * 8, menu_cursor * 8, 4, vdp1_tile_address, ">");
+
+      for (i = 0; i < 6; i++)
+      {
+         sprintf(str, "%s: %02x", value_names[i], values[i]);
+         vdp1_print_str(21 * 8, i * 8, 4, vdp1_tile_address, str);
+      }
+
+      u16 val1 = (control[4] & 0x1f) << 5;//upper 5 bits of internal eg value
+      u16 val2 = (control[4] >> 5) & 3;//current envelope state
+      sprintf(str, "%04x  %01x", val1, val2);
+      vdp1_print_str(21 * 8, 27 * 8, 4, vdp1_tile_address, str);
+
+      for (i = 0; i < 28; i++)
+      {
+         sprintf(str, "%02x %03x %01x", results[i].frame, results[i].env_value, results[i].env_state);
+         vdp1_print_str(30 * 8, i * 8, 4, vdp1_tile_address, str);
+      }
+
+      vdp_end_draw_list();
+
+      if (
+         per[0].but_push_once & PAD_A ||
+         per[0].but_push_once & PAD_B ||
+         per[0].but_push_once & PAD_C)
+      {
+         struct SlotRegs slot = { 0 };
+
+         slot.sa = addr;
+         slot.lsa = 0;
+         slot.lea = 15;
+
+         slot.lpctl = 1;
+         slot.oct = 0xb;
+         slot.fns = 0;
+         slot.disdl = 7;
+
+         slot.ar = values[0];
+         slot.d1r = values[1];
+         slot.d2r = values[2];
+         slot.rr = values[3];
+         slot.dl = values[4];
+         slot.krs = values[5];
+         slot.hold = values[6];
+
+         all_note_off();
+
+         test_active = 1;
+         test_frame = 0;
+         result_record_pos = 0;
+
+         write_note_struct(0, &slot);
+
+         if(per[0].but_push_once & PAD_B)
+         {
+            write_keyoff = 1;
+            keyoff_timer = 0;
+            keyoff_limit = 10;
+         }
+
+         if (per[0].but_push_once & PAD_C)
+         {
+            write_keyoff = 1;
+            keyoff_timer = 0;
+            keyoff_limit = 2;
+         }
+      }
+
+      if (per[0].but_push_once & PAD_UP)
+      {
+         menu_cursor--;
+
+         if (menu_cursor < 0)
+            menu_cursor = 0;
+      }
+
+      if (per[0].but_push_once & PAD_DOWN)
+      {
+         menu_cursor++;
+      }
+
+      if (per[0].but_push_once & PAD_LEFT)
+      {
+         values[menu_cursor]--;
+      }
+
+      if (per[0].but_push_once & PAD_RIGHT)
+      {
+         values[menu_cursor]++;
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+//sweep entire pitch spectrum
+void scsp_full_sweep()
+{
+   const u32 vdp1_tile_address = 0x10000;
+
+   vdp1_setup(vdp1_tile_address);
+
+   int addr = 0;
+
+   scsp_setup(addr);
+
+   int monitor = 0;
+
+   int oct = 10;
+   int fns = 0;
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      fns += 10;
+
+      if (fns >= 0x3FF)
+         fns = 0;
+
+      volatile u16* slot_ptr = (u16 *)0x25b00000;
+
+      int offset = 0 * 0x10;
+
+      slot_ptr[offset + 8] = (oct << 11) | fns;//oct,fns
+
+      vdp1_boilerplate();
+
+      display_registers(monitor, vdp1_tile_address);
+
+      vdp_end_draw_list();
+
+      if (per[0].but_push_once & PAD_UP)
+      {
+         oct++;
+
+         if (oct > 0xf)
+            oct = 0xf;
+      }
+
+      if (per[0].but_push_once & PAD_DOWN)
+      {
+         oct--;
+
+         if (oct < 0)
+            oct = 0;
+      }
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         struct SlotRegs slot = { 0 };
+
+         slot.sa = addr;
+         slot.lsa = 0;
+         slot.lea = 15;
+
+         slot.lpctl = 1;
+         slot.disdl = 7;
+
+         slot.ar = 0x1f;
+
+         all_note_off();
+
+         write_note_struct(0, &slot);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+//test different starting addresses
+void scsp_address_decode()
+{
+   const u32 vdp1_tile_address = 0x10000;
+
+   vdp1_setup(vdp1_tile_address);
+
+   int addr = 0;
+
+   scsp_setup(addr);
+
+   int monitor = 0;
+
+   int oct = 10;
+   int fns = 0;
+
+   char str[128] = { 0 };
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      volatile u16* slot_ptr = (u16 *)0x25b00000;
+
+      int offset = 0 * 0x10;
+
+      slot_ptr[offset + 8] = (oct << 11) | fns;//oct,fns
+
+      vdp1_boilerplate();
+
+      display_registers(monitor, vdp1_tile_address);
+
+      sprintf(str, "%04x", addr);
+      vdp1_print_str(21 * 8, 27 * 8, 4, vdp1_tile_address, str);
+
+      vdp_end_draw_list();
+
+      if (per[0].but_push_once & PAD_UP)
+      {
+         oct++;
+
+         if (oct > 0xf)
+            oct = 0xf;
+      }
+
+      if (per[0].but_push_once & PAD_DOWN)
+      {
+         oct--;
+
+         if (oct < 0)
+            oct = 0;
+      }
+
+      if (per[0].but_push_once & PAD_A ||
+         per[0].but_push_once & PAD_B ||
+         per[0].but_push_once & PAD_C ||
+         per[0].but_push_once & PAD_X ||
+         per[0].but_push_once & PAD_Y ||
+         per[0].but_push_once & PAD_Z)
+      {
+         struct SlotRegs slot = { 0 };
+
+
+         if (per[0].but_push_once & PAD_A)
+            addr -= 0x10;
+
+         if (per[0].but_push_once & PAD_X)
+            addr += 0x10;
+
+         if (per[0].but_push_once & PAD_B)
+            addr -= 0x100;
+
+         if (per[0].but_push_once & PAD_Y)
+            addr += 0x100;
+
+         if (per[0].but_push_once & PAD_C)
+            addr -= 0x1000;
+
+         if (per[0].but_push_once & PAD_Z)
+            addr += 0x1000;
+
+         if (addr < 0)
+            addr = 0;
+
+         slot.sa = addr;
+         slot.lsa = 0;
+         slot.lea = 15;
+
+         slot.lpctl = 1;
+         slot.disdl = 7;
+
+         slot.ar = 0x1f;
+
+         all_note_off();
+
+         write_note_struct(0, &slot);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+void scsp_fm_slot_connection()
+{
+   u32 addr = 0;
+
+   const u32 vdp1_tile_address = 0x10000;
+
+   vdp1_setup(vdp1_tile_address);
+
+   scsp_setup(addr);
+
+   struct SlotRegs slot = { 0 };
+
+   slot.sa = addr;
+   slot.lpctl = 1;
+   slot.oct = 0xf;
+   slot.fns = 0;
+   slot.disdl = 7;
+   slot.lsa = 0;
+   slot.lea = 15;
+   slot.ar = 0x1f;
+
+   write_note_struct(0, &slot);
+
+   int mdxsl = 0x20;
+   int mdl = 0xa;
+
+   char str[128] = { 0 };
+
+   int i;
+
+   u32 sound_len = 1024*3;
+
+   volatile u16* sound_ram_ptr_16 = (u16 *)(0x25a00000);
+
+   for (i = 0; i < sound_len; i++)
+   {
+      sound_ram_ptr_16[i] = sine_tbl[i & 0xff] << 8;
+   }
+
+   volatile u16* control = (u16 *)(0x25b00400);
+
+   int monitor = 0xa;
+
+   int capture = 0;
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      control[4] = monitor << 11;
+
+      vdp1_boilerplate();
+
+      display_registers(monitor, vdp1_tile_address);
+
+      if (per[0].but_push_once & PAD_UP)
+      {
+         mdxsl++;
+      }
+      if (per[0].but_push_once & PAD_DOWN)
+      {
+         mdxsl--;
+
+         if (mdxsl < 0)
+            mdxsl = 0;
+      }
+      if (per[0].but_push_once & PAD_LEFT)
+      {
+         mdl--;
+      }
+      if (per[0].but_push_once & PAD_RIGHT)
+      {
+         mdl++;
+
+         if (mdl > 0xf)
+            mdl = 0xf;
+      }
+
+      if (per[0].but_push_once & PAD_L)
+      {
+         monitor--;
+
+         if (monitor < 0)
+            monitor = 0;
+      }
+
+      if (per[0].but_push_once & PAD_R)
+      {
+         monitor++;
+      }
+
+      sprintf(str, "mdxsl: %02x mdl: %02x", mdxsl, mdl);
+      vdp1_print_str(20 * 8, 0 * 8, 4, vdp1_tile_address, str);
+
+      u16 ca = (control[4] >> 7) & 0xf;
+      sprintf(str, "ca: %04x mon: %04x %04x", ca, monitor, capture);
+      vdp1_print_str(20 * 8, 16 * 8, 4, vdp1_tile_address, str);
+
+      vdp_end_draw_list();
+
+      //one modulator both slots
+      if (per[0].but_push_once & PAD_X)
+      {
+         slot.krs = 0xf;
+         slot.sd = 1;
+         slot.tl = 0;
+         slot.sa = 1024;
+         slot.lsa = 0;
+         slot.lea = 1023;
+
+         slot.ar = 0x1f;
+         slot.hold = 0;
+         slot.d1r = 0;
+         slot.d2r = 0;
+         slot.rr = 0;
+         slot.dl = 0;
+         slot.disdl = 7;
+
+         slot.mdl = mdl;
+         slot.mdxsl = mdxsl;
+         slot.mdysl = mdxsl;
+
+         all_note_off();
+
+         write_note_struct(monitor + 0, &slot);
+
+         slot.sa = 1024;
+         slot.lsa = 0;
+         slot.lea = 1023;
+
+         slot.ar = 0x1f;
+         slot.hold = 0;
+         slot.d1r = 0;
+         slot.d2r = 0;
+         slot.rr = 0;
+         slot.dl = 0;
+
+         slot.disdl = 0;
+
+         slot.mdl = 0;
+         slot.mdxsl = 0;
+         slot.mdysl = 0;
+
+         write_note_struct(monitor + 1, &slot);
       }
 
       if (per[0].but_push_once & PAD_START)

--- a/yabauseut/src/vdp2.c
+++ b/yabauseut/src/vdp2.c
@@ -3234,6 +3234,240 @@ void linecount_test()
 
 //////////////////////////////////////////////////////////////////////////////
 
+u32 coef[] = { 0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80008000,0x80001c20,0x0e100960,0x070805a0,0x04b00404,0x03840320,0x02d0028e,0x02580229,0x020201e0,0x01c201a7,0x0190017a,0x01680156,0x01470139,0x012c0120,0x0114010a,0x010100f8,0x00f000e8,0x00e100da,0x00d300cd,0x00c800c2,0x00bd00b8,0x00b400af,0x00ab00a7,0x00a300a0,0x00a0009c,0x00990096,0x00920090,0x008d008a,0x00870085,0x00820080,0x007e007c,0x007a0078,0x00760074,0x00720070,0x006e006d,0x006b0069,0x00680066,0x00650064,0x00620061,0x0060005e,0x005d005c,0x005b005a,0x00580057,0x00560055,0x00540053,0x00520051,0x00500050,0x004f004e,0x004d004c,0x004b004b,0x004a0049,0x00480048,0x00470046,0x00450045,0x00440043,0x00430042,0x00420041,0x00400040,0x003f003f,0x003e003e,0x003d003d,0x003c003c,0x003b003b,0x003a003a,0x00390039,0x00380038,0x00370037,0x00360036,0x00360035,0x00350034,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x000001b2,0x01ce01c3,0x01ba01b3,0x01b201b7,0x01bb01be,0x01c101c4,0x01c701c9,0x01cb01cd,0x01cf01ce,0x01cd01cb,0x01ca01c8,0x01c701c6,0x01c401c3,0x01c201c1,0x01c001bf,0x01be01bd,0x01bc01bb,0x01ba01ba,0x01b901b8,0x01b701b6,0x01b601b5,0x01b401b4,0x01b301b2,0x01b201b1,0x01b101b0,0x01b001b0,0x01b101b1,0x01b201b2,0x01b301b3 };
+
+u32 table[] =
+{
+   0x0000,0x0000,//xst
+   0x0000,0x0000,//yst
+   0x0000,0x0000,//zst
+   0x0000,0x0000,//dxst
+   0x0001,0x0000,//dyst
+   0x0001,0x0000,//dx
+   0x0000,0x0000,//dy
+   0x0002,0xe939,//a
+   0x0000,0x06da,//b
+   0x0000,0x4599,//c
+   0xffff,0xba0f,//d
+   0x0000,0x490c,//e
+   0x0002,0xe5a0,//f
+   0x00b0,//px
+   0x0070,//py
+   0x0100,//pz
+   0x0000,
+   0x00b0,//cx
+   0x0070,//cy
+   0x0100,//cz
+   0x0000,
+   0x065d,0xd9f8,//mx
+   0x0a6f,0x1988,//my
+   0x0002,0xec84,//kx
+   0x0002,0xec84,//ky
+   0xf000,0x0000,//kast (coef table addr)
+   0x0001,0x0000,//dkast
+   0xfef9,0x43c0,//dkax
+   0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000,0x8000
+};
+
+void init_rbg0(u32 map_offset, u32 param_offset, u32 ktaof, u32 coef_data_size, u32 deltakax)
+{
+   int i;
+
+   volatile u32 * vram_ptr = (volatile u32 *)(0x25E00000);
+   u32 param_addr = 0x25E00000 + (param_offset * 0x20000) + 0xE000;
+
+   for (i = 0; i < 0x20000; i++)
+      vram_ptr[i] = 0;
+
+   // Setup a screen for us draw on
+   test_disp_settings.is_bitmap = TRUE;
+   test_disp_settings.bitmap_size = BG_BITMAP512x256;
+   test_disp_settings.transparent_bit = 0;
+   test_disp_settings.color = BG_256COLOR;
+   test_disp_settings.special_priority = 0;
+   test_disp_settings.special_color_calc = 0;
+   test_disp_settings.extra_palette_num = 0;
+   test_disp_settings.map_offset = map_offset;
+   test_disp_settings.rotation_mode = 0;
+   test_disp_settings.parameter_addr = param_addr;
+   vdp_rbg0_init(&test_disp_settings);
+
+   // Use the default palette
+   vdp_set_default_palette();
+
+   // Setup an 8x8 1BPP font
+   test_disp_font.data = font_8x8;
+   test_disp_font.width = 8;
+   test_disp_font.height = 8;
+   test_disp_font.bpp = 1;
+   vdp_set_font(SCREEN_RBG0, &test_disp_font, 1);
+   test_disp_font.out = (u8 *)(0x25E00000 + (map_offset * 0x20000));//vdp_set_font bug workaround
+
+   vdp_rbg0_init(&test_disp_settings);
+   vdp_set_default_palette();
+
+   for (i = 0; i < 16; i++)
+      vdp_printf(&test_disp_font, 0 * 8, i * 16, 15, "RBG0 RBG0 RBG0 RBG0 RBG0 RBG0 RBG0 RBG0 RBG0 RBG0 RBG0 RBG0");
+
+   VDP2_REG_CYCB0L = 0xffff;
+   VDP2_REG_CYCB0U = 0xffff;
+   VDP2_REG_CYCB1L = 0xffff;
+   VDP2_REG_CYCB1U = 0xffff;
+
+   VDP2_REG_RAMCTL = 0x1300 | (3 << (map_offset * 2)) | (1 << (ktaof * 2));
+
+   VDP2_REG_KTAOF = ktaof;
+   VDP2_REG_KTCTL = 0x0003;
+
+   VDP2_REG_RPRCTL = 0x0000;
+   VDP2_REG_RPMD = 0x0000;
+   volatile u16 * rot_table_ptr = (volatile u16 *)param_addr;
+
+   for (i = 0; i < 64; i++)
+   {
+      rot_table_ptr[i] = table[i];
+   }
+
+   u32 addr = (ktaof * 0x10000 + deltakax) * coef_data_size;
+   volatile u32 * coef_ptr = (volatile u32 *)(0x25E00000 | addr);
+
+   //write coef
+   for (i = 0; i < 224; i++)
+   {
+      coef_ptr[i] = coef[i];
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp1_print_char(int x, int y, int palette, u32 vdp1_tile_address, char c)
+{
+   sprite_struct quad = { 0 };
+
+   quad.x = x;
+   quad.y = y;
+   quad.height = 8;
+   quad.width = 8;
+   quad.bank = (palette << 4);
+   quad.addr = vdp1_tile_address + (c * 32);
+
+   vdp_draw_normal_sprite(&quad);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp1_print_str(int x, int y, int palette, u32 vdp1_tile_address, char* str)
+{
+   int i;
+   int len = strlen(str);
+
+   for (i = 0; i < len; i++)
+   {
+      vdp1_print_char(x + (i * 8), y, palette, vdp1_tile_address, str[i]);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void rbg0_delta_kax_test()
+{
+   //vdp1 setup
+   const u32 vdp1_tile_address = 0x10000;
+   load_font_8x8_to_vram_1bpp_to_4bpp(vdp1_tile_address, VDP1_RAM);
+   VDP1_REG_PTMR = 0x02;//draw automatically with frame change
+   VDP2_REG_PRISA = 7 | (6 << 8);
+   VDP2_REG_PRISB = 5 | (4 << 8);
+   VDP2_REG_PRISC = 3 | (2 << 8);
+   VDP2_REG_PRISD = 1 | (0 << 8);
+   VDP2_REG_SPCTL = (0 << 12) | (0 << 8) | (0 << 5) | 7;
+
+   u32 map_offset = 0;
+   u32 param_offset = 0;
+   u32 param_addr = 0x25E00000 + (param_offset * 0x20000) + 0xE000;
+   u32 ktaof = 0;
+   u32 coef_data_size = 2;
+   u32 deltakax = 0xf000;
+
+   init_rbg0(map_offset, param_offset, ktaof, coef_data_size, deltakax);
+
+   int q = 0;
+   volatile u32 * dkax = (volatile u32 *)(param_addr + 0x5c);
+   char str[128] = { 0 };
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      vdp_start_draw_list();
+      sprite_struct quad = { 0 };
+
+      //system clipping
+      quad.x = 320;
+      quad.y = 224;
+
+      vdp_system_clipping(&quad);
+
+      //user clipping
+      quad.x = 0;
+      quad.y = 0;
+      quad.x2 = 320;
+      quad.y2 = 224;
+
+      vdp_user_clipping(&quad);
+
+      quad.x = 0;
+      quad.y = 0;
+
+      vdp_local_coordinate(&quad);
+
+      sprintf(str, "map offset %01X, param offset %01X, ktaof %01X", map_offset, param_offset, ktaof);
+
+      vdp1_print_str(0, 0, 4, vdp1_tile_address, str);
+
+      vdp_end_draw_list();
+
+      dkax[0] = q;
+      q += 10000;
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         map_offset++;
+
+         if (map_offset > 3)
+            map_offset = 0;
+      }
+
+      if (per[0].but_push_once & PAD_B)
+      {
+         ktaof++;
+
+         if (ktaof > 3)
+            ktaof = 0;
+      }
+
+      if (per[0].but_push_once & PAD_C)
+      {
+         param_offset++;
+
+         if (param_offset > 3)
+            param_offset = 0;
+      }
+
+      if (per[0].but_push_once & PAD_Z)
+      {
+         q = 0;
+         init_rbg0(map_offset, param_offset, ktaof, coef_data_size, deltakax);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 void vdp2_auto_tests()
 {
    auto_test_section_start("Vdp2 screenshot tests");

--- a/yabauseut/src/vdp2.c
+++ b/yabauseut/src/vdp2.c
@@ -1453,6 +1453,367 @@ void vdp2_sprite_priority_shadow_test()
 
 //////////////////////////////////////////////////////////////////////////////
 
+void draw_grid(int clipping_mode)
+{
+   sprite_struct quad = { 0 };
+
+   int j;
+
+   quad.bank = 3;
+   quad.attr = (1 << 10) | (clipping_mode << 9);
+   for (j = 0; j < 40; j++)
+   {
+      quad.x = j * 8;
+      quad.y = 0;
+      quad.x2 = j * 8;
+      quad.y2 = 224;
+
+      vdp_draw_line(&quad);
+   }
+
+   for (j = 0; j < 40; j++)
+   {
+      quad.x = 0;
+      quad.y = j * 8;
+      quad.x2 = 321;
+      quad.y2 = j * 8;
+
+      vdp_draw_line(&quad);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void scaled_sprite(int x, int y, int x3, int y3, u32 vdp1_tile_address, int flip)
+{
+   sprite_struct quad = { 0 };
+
+   quad.width = 8;
+   quad.height = 8;
+
+   int palette = 3;
+
+   quad.x = x;
+   quad.y = y;
+   quad.x2 = 0;
+   quad.y2 = 0;
+
+   quad.x3 = x3;
+   quad.y3 = y3;
+
+   quad.bank = (palette << 4);
+
+   quad.addr = vdp1_tile_address + ('a' * 32);
+
+   quad.attr = (flip << 4) << 12 | 0x80;
+
+   vdp_draw_scaled_sprite(&quad);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void draw_scaled_sprites(int x, int y, u32 vdp1_tile_address, int flip)
+{
+   //x1 < x2, y1 < y2
+   scaled_sprite(
+      x,
+      y,
+      x + 7,
+      y + 7, vdp1_tile_address, flip);
+
+   //x2 < x1, y1 < y2
+   scaled_sprite(
+      x + 16 + 7,
+      y + 0,
+      x + 16,
+      y + 0 + 7, vdp1_tile_address, flip);
+
+   //x1 < x2, y2 < y1
+   scaled_sprite(
+      x + 48,
+      y + 0 + 7,
+      x + 48 + 7,
+      y + 0, vdp1_tile_address, flip);
+
+   //x2 < x1, y2 < y1
+   scaled_sprite(
+      x + 32 + 7,
+      y + 0 + 7,
+      x + 32,
+      y + 0, vdp1_tile_address, flip);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp1_scaled_sprite_clipping_latch()
+{
+   const u32 vdp2_tile_address = 0x40000;
+   const u32 vdp1_tile_address = 0x10000;
+   vdp2_basic_tile_scroll_setup(vdp2_tile_address);
+
+   load_font_8x8_to_vram_1bpp_to_4bpp(vdp1_tile_address, VDP1_RAM);
+
+   VDP1_REG_PTMR = 0x02;//draw automatically with frame change
+
+   VDP2_REG_PRISA = 7 | (6 << 8);
+   VDP2_REG_PRISB = 5 | (4 << 8);
+   VDP2_REG_PRISC = 3 | (2 << 8);
+   VDP2_REG_PRISD = 1 | (0 << 8);
+
+   int tvm = 0;
+   int hreso = 0;
+   int lsmd = 0;
+   int die = 0;
+   int dil = 0;
+
+   vdp_start_draw_list();
+   sprite_struct quad = { 0 };
+
+   //system clipping
+   quad.x = 320 - 8;
+   quad.y = 224 - 8;
+
+   vdp_system_clipping(&quad);
+
+   //user clipping
+   quad.x = 0;
+   quad.y = 0;
+   quad.x2 = 320 - 16;
+   quad.y2 = 224 - 16;
+
+   vdp_user_clipping(&quad);
+
+   vdp_end_draw_list();
+
+   struct Pos
+   {
+      int x, y;
+   };
+
+   struct Pos system_clipping = { 0 };
+
+   system_clipping.x = 319 - 8;
+   system_clipping.y = 223 - 8;
+
+   struct UserClipping
+   {
+      struct Pos a, b;
+   };
+
+   struct UserClipping user_clipping = { { 0 } };
+
+   user_clipping.a.x = 8;
+   user_clipping.a.y = 8;
+
+   user_clipping.b.x = 319 - 16;
+   user_clipping.b.y = 223 - 16;
+
+   int clipping_mode = 0;
+
+   struct Preset
+   {
+      struct Pos system_clipping;
+      struct UserClipping user_clipping;
+      int clipping_mode;
+   };
+
+   int num_presets = 7;
+
+   struct Preset presets[7] =
+   {
+      //normal setting
+      {
+         { 0x28, 0x28 },
+         { { 0x08, 0x08 },{ 0x20, 0x20 } },
+         0
+      },
+      //user x1 < user x0
+      {
+         { 0x28, 0x28 },
+         { { 0x20, 0x08 },{ 0x08, 0x20 } },
+         0
+      },
+      //user y1 < user y0
+      {
+         { 0x28, 0x28 },
+         { { 0x08, 0x20 },{ 0x20, 0x08 } },
+         0
+      },
+      //user x1 < user x0, user y1 < user y0
+      {
+         { 0x28, 0x28 },
+         { { 0x20, 0x20 },{ 0x08, 0x08 } },
+         0
+      },
+      //user x1 > system x
+      {
+         { 0x28, 0x28 },
+         { { 0x08, 0x08 },{ 0x30, 0x20 } },
+         0
+      },
+      //user y1 > system y
+      {
+         { 0x28, 0x28 },
+         { { 0x08, 0x08 },{ 0x20, 0x30 } },
+         0
+      },
+      //user x1 > system x, user y1 > system y
+      {
+         { 0x28, 0x28 },
+         { { 0x08, 0x08 },{ 0x30, 0x30 } },
+         0
+      },
+   };
+
+   int current_preset = 0;
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      VDP1_REG_TVMR = tvm;
+
+      VDP1_REG_FBCR = ((die & 1) << 3) | ((dil & 1) << 2);
+
+      VDP2_REG_TVMD = (1 << 15) | (lsmd << 6) | hreso;
+
+      vdp_start_draw_list();
+
+      if (per[0].but_push & PAD_A)
+      {
+         if (per[0].but_push & PAD_LEFT)
+            system_clipping.x--;
+         if (per[0].but_push & PAD_RIGHT)
+            system_clipping.x++;
+         if (per[0].but_push & PAD_UP)
+            system_clipping.y--;
+         if (per[0].but_push & PAD_DOWN)
+            system_clipping.y++;
+      }
+
+      quad.x = system_clipping.x;
+      quad.y = system_clipping.y;
+
+      vdp_system_clipping(&quad);
+
+      if (per[0].but_push & PAD_B)
+      {
+         if (per[0].but_push & PAD_L)
+         {
+            if (per[0].but_push & PAD_LEFT)
+               user_clipping.a.x--;
+            if (per[0].but_push & PAD_RIGHT)
+               user_clipping.a.x++;
+            if (per[0].but_push & PAD_UP)
+               user_clipping.a.y--;
+            if (per[0].but_push & PAD_DOWN)
+               user_clipping.a.y++;
+         }
+         else
+         {
+            if (per[0].but_push & PAD_LEFT)
+               user_clipping.b.x--;
+            if (per[0].but_push & PAD_RIGHT)
+               user_clipping.b.x++;
+            if (per[0].but_push & PAD_UP)
+               user_clipping.b.y--;
+            if (per[0].but_push & PAD_DOWN)
+               user_clipping.b.y++;
+         }
+      }
+
+      quad.x = user_clipping.a.x;
+      quad.y = user_clipping.a.y;
+      quad.x2 = user_clipping.b.x;
+      quad.y2 = user_clipping.b.y;
+
+      vdp_user_clipping(&quad);
+
+      quad.x = 0;
+      quad.y = 0;
+      quad.x2 = 0;
+      quad.y2 = 0;
+
+      vdp_local_coordinate(&quad);
+
+      draw_grid(clipping_mode);
+
+      draw_scaled_sprites(0, 0, vdp1_tile_address, 0);
+      draw_scaled_sprites(0, 16, vdp1_tile_address, 1);
+      draw_scaled_sprites(0, 32, vdp1_tile_address, 2);
+      draw_scaled_sprites(0, 48, vdp1_tile_address, 3);
+
+      vdp_end_draw_list();
+
+      char status[64] = "";
+
+      sprintf(status, "clip mode = %02x", clipping_mode);
+      write_str_as_pattern_name_data(0, 24, status, 3, 0x000000, vdp2_tile_address);
+      sprintf(status, "sys x =%02x sys y =%02x  ", system_clipping.x, system_clipping.y);
+      write_str_as_pattern_name_data(0, 25, status, 3, 0x000000, vdp2_tile_address);
+      sprintf(status, "usr x0=%02x usr y0=%02x  ", user_clipping.a.x, user_clipping.a.y);
+      write_str_as_pattern_name_data(0, 26, status, 3, 0x000000, vdp2_tile_address);
+      sprintf(status, "usr x1=%02x usr y1=%02x  ", user_clipping.b.x, user_clipping.b.y);
+      write_str_as_pattern_name_data(0, 27, status, 3, 0x000000, vdp2_tile_address);
+
+      if (per[0].but_push_once & PAD_R)
+      {
+         clipping_mode++;
+
+         clipping_mode &= 3;
+      }
+
+      if (per[0].but_push_once & PAD_C)
+      {
+         tvm = !tvm;
+      }
+
+      if (per[0].but_push_once & PAD_X)
+      {
+         if (hreso == 2)
+            hreso = 0;
+         else
+            hreso = 2;
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         reset_system();
+      }
+
+      if (per[0].but_push_once & PAD_Z)
+      {
+         system_clipping.x = presets[current_preset].system_clipping.x;
+         system_clipping.y = presets[current_preset].system_clipping.y;
+         user_clipping.a.x = presets[current_preset].user_clipping.a.x;
+         user_clipping.a.y = presets[current_preset].user_clipping.a.y;
+         user_clipping.b.x = presets[current_preset].user_clipping.b.x;
+         user_clipping.b.y = presets[current_preset].user_clipping.b.y;
+         clipping_mode = presets[current_preset].clipping_mode;
+
+         current_preset++;
+
+         if (current_preset >= num_presets)
+            current_preset = 0;
+      }
+
+      if (per[0].but_push_once & PAD_L)
+      {
+         if (die == 0)
+            die = 1;
+         else
+            die = 0;
+      }
+
+      if (per[0].but_push_once & PAD_START)
+         break;
+   }
+
+   vdp2_basic_tile_scroll_deinit();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 void vdp2_change_4bbp_tile_color(u32 address, int amount)
 {
    int i;
@@ -2538,7 +2899,7 @@ void vdp2_window_test ()
 
 //////////////////////////////////////////////////////////////////////////////
 
-void draw_square_sprite(int x, int y, int size, int bank, int vdp1_tile_address, int offset)
+void draw_square_sprite(int x, int y, int size, int bank, int vdp1_tile_address, int offset, int msb)
 {
    sprite_struct quad = { 0 };
 
@@ -2558,12 +2919,34 @@ void draw_square_sprite(int x, int y, int size, int bank, int vdp1_tile_address,
    quad.bank = bank << 4;
    quad.width = 8;
    quad.height = 8;
-   quad.attr = (1 << 15);
+   quad.attr = (msb << 15);
 
    vdp_draw_distorted_sprite(&quad);
 }
 
 //////////////////////////////////////////////////////////////////////////////
+
+struct Wctl {
+   int logic;
+   int w0_enable;
+   int w1_enable;
+   int sw_enable;
+   int w0_area;
+   int w1_area;
+   int sw_area;
+};
+
+u8 make_wctl(struct Wctl bg)
+{
+   return
+      (bg.w0_area << 0) |
+      (bg.w0_enable << 1) |
+      (bg.w1_area << 2)|
+      (bg.w1_enable << 3) |
+      (bg.sw_area << 4) |
+      (bg.sw_enable << 5) |
+      (bg.logic << 7);
+}
 
 void vdp2_sprite_window_test()
 {
@@ -2582,62 +2965,81 @@ void vdp2_sprite_window_test()
    spr.y = 0;
    vdp_local_coordinate(&spr);
 
-   draw_square_sprite(8, 8, 64, 4, vdp1_tile_address, (2 * 32));
+   draw_square_sprite(2, 4, 8 * 12, 4, vdp1_tile_address, (2 * 32), 0);
+   draw_square_sprite(2, 2, 8 * 12, 4, vdp1_tile_address, (2 * 32), 1);
 
    vdp_end_draw_list();
 
+   volatile u16 * color_ram_ptr = (volatile u16 *)VDP2_CRAM;
+   color_ram_ptr[0] = 0x3105;
+
    int i;
-   for (i = 0; i < 32; i += 3)
+   for (i = 0; i < 32; i += 2)
    {
-      write_str_as_pattern_name_data_special(0, 0 + i, "\n\n\n\nNBG1\n\n\n\n\n\n\n\n", 4, 0x004000, vdp2_tile_address, 0, 0);
-      write_str_as_pattern_name_data_special(0, 1 + i, "\n\n\n\nNBG2\n\n\n\n\n\n\n\n", 5, 0x008000, vdp2_tile_address, 0, 0);
-      write_str_as_pattern_name_data_special(0, 2 + i, "\n\n\n\nNBG3\n\n\n\n\n\n\n\n", 6, 0x00C000, vdp2_tile_address, 0, 0);
+      write_str_as_pattern_name_data_special(0, 0 + i, "\n\n\n\nNBG2\n\n\n\n\n\n\n\n", 5, 0x008000, vdp2_tile_address, 0, 0);
+      write_str_as_pattern_name_data_special(0, 1 + i, "\n\n\n\nNBG3\n\n\n\n\n\n\n\n", 6, 0x00C000, vdp2_tile_address, 0, 0);
    }
 
    //vars for reg adjuster
    struct {
       int sprite_window_enable;
-      struct {
-         int sprite_window_enable;
-         int sprite_window_area;
-      }nbg[4];
+      struct Wctl nbg[2];
+      struct Wctl spr;
    }v = { 0 };
 
    struct RegAdjusterState s = { 0 };
 
    ra_add_var(&s, &v.sprite_window_enable, "Sprite window enabl", 1);
 
-   for (i = 1; i < 4; i++)
+   for (i = 0; i < 2; i++)
    {
       char str[64] = { 0 };
-      sprintf(str, "NBG%d spr win enabl ", i);
-      ra_add_var(&s, &v.nbg[i].sprite_window_enable, str, 1);
-      sprintf(str, "NBG%d spr win area  ", i);
-      ra_add_var(&s, &v.nbg[i].sprite_window_area, str, 1);
+      sprintf(str, "NBG%d spr win enabl ", i + 2);
+      ra_add_var(&s, &v.nbg[i].sw_enable, str, 1);
+      sprintf(str, "NBG%d spr win area  ", i + 2);
+      ra_add_var(&s, &v.nbg[i].sw_area, str, 1);
+      sprintf(str, "NBG%d transp logic  ", i + 2);
+      ra_add_var(&s, &v.nbg[i].logic, str, 1);
+      sprintf(str, "NBG%d w0 enable  ", i + 2);
+      ra_add_var(&s, &v.nbg[i].w0_enable, str, 1);
+      sprintf(str, "NBG%d w1 enable  ", i + 2);
+      ra_add_var(&s, &v.nbg[i].w1_enable, str, 1);
+      sprintf(str, "NBG%d w0 area  ", i + 2);
+      ra_add_var(&s, &v.nbg[i].w0_area, str, 1);
+      sprintf(str, "NBG%d w1 area  ", i + 2);
+      ra_add_var(&s, &v.nbg[i].w1_area, str, 1);
    }
 
-   int presets[][31] =
+   ra_add_var(&s, &v.spr.logic, "sprite transp logic", 1);
+   ra_add_var(&s, &v.spr.sw_enable, "spr use spr win", 1);
+   ra_add_var(&s, &v.spr.sw_area, "spr sprite win area", 1);
+   ra_add_var(&s, &v.spr.w1_enable, "sprite w1 enab", 1);
+   ra_add_var(&s, &v.spr.w1_area, "sprite w1 area", 1);
+   ra_add_var(&s, &v.spr.w0_enable, "sprite w0 enab", 1);
+   ra_add_var(&s, &v.spr.w0_area, "sprite w0 area", 1);
+
+   int presets[][22] =
    {
       //preset 0
       {
          //sprite window enable
-         1,
-         //nbg1
-         1, 0,
+         0,
          //nbg2
-         1, 0,
+         0, 0, 0, 0, 0, 0, 0,
          //nbg3
-         1, 0
+         0, 0, 0, 0, 0, 0, 0,
+         //sprite
+         0, 0, 0, 0, 0, 0, 0
       },
       {
          //sprite window enable
-         1,
-         //nbg1
-         1, 1,
+         0,
          //nbg2
-         1, 1,
+         0, 0, 0, 0, 0, 0, 0,
          //nbg3
-         1, 1
+         0, 0, 0, 0, 0, 0, 0,
+         //sprite
+         1, 0, 1, 0, 0, 0, 0
       }
    };
 
@@ -2651,13 +3053,19 @@ void vdp2_sprite_window_test()
 
       VDP2_REG_SPCTL = (v.sprite_window_enable << 4) | 7;
 
-      VDP2_REG_WCTLA =
-         (v.nbg[0].sprite_window_enable << 5) | (v.nbg[1].sprite_window_enable << 13) |
-         (v.nbg[0].sprite_window_area << 4) | (v.nbg[1].sprite_window_area << 12);
+      VDP2_REG_WCTLB = (make_wctl(v.nbg[1]) << 8) | make_wctl(v.nbg[0]);
 
-      VDP2_REG_WCTLB =
-         (v.nbg[2].sprite_window_enable << 5) | (v.nbg[3].sprite_window_enable << 13) |
-         (v.nbg[2].sprite_window_area << 4) | (v.nbg[3].sprite_window_area << 12);
+      VDP2_REG_WCTLC = make_wctl(v.spr) << 8;
+
+      VDP2_REG_WPSX0 = (1*8)*2;
+      VDP2_REG_WPSY0 = 1*8;
+      VDP2_REG_WPEX0 = ((9 * 8) * 2)-1;
+      VDP2_REG_WPEY0 = (8*9)-1;
+
+      VDP2_REG_WPSX1 = (7 * 8) * 2;
+      VDP2_REG_WPSY1 = 1*8;
+      VDP2_REG_WPEX1 = ((14 * 8) * 2)-1;
+      VDP2_REG_WPEY1 = (8*9)-1;
 
       ra_update_vars(&s);
 


### PR DESCRIPTION
Applying the following Yabause PRs/wild-commits (ignoring changes on Qt UI):

*[b4f6cb32aee4918aa9436e4c13ae1a3988193b57](https://github.com/Yabause/yabause/commit/b4f6cb32aee4918aa9436e4c13ae1a3988193b57): Show game name instead of filename in android port
*[716791c8cca0a1234894d5ae735d2793dd2265f3](https://github.com/Yabause/yabause/commit/716791c8cca0a1234894d5ae735d2793dd2265f3): Removed useless headers
*[190](https://github.com/Yabause/yabause/pull/190): vidsoft: fix f1 challenge map when zoomed out
*[193](https://github.com/Yabause/yabause/pull/193): vidsoft: fix incorrect colors on characters in dead or alive
*[195](https://github.com/Yabause/yabause/pull/195): idsoft: improve user and system clipping
*[196](https://github.com/Yabause/yabause/pull/196): add msys2 x86_64 build to appveyor
*[197](https://github.com/Yabause/yabause/pull/197): vidsoft: fix sprite window in cotton boomerang and winter heat
*[199](https://github.com/Yabause/yabause/pull/199): vidsoft: improve sonic 2 two player mode
*[200](https://github.com/Yabause/yabause/pull/200): vidsoft: fix sonic r and all star baseball 97 backgrounds
*[201](https://github.com/Yabause/yabause/pull/201): qt/vidsoft: add integer video scaling option in windowed mode
*[205](https://github.com/Yabause/yabause/pull/205): Fixed issues with emulated mouse and qt mouse
*[208](https://github.com/Yabause/yabause/pull/208): scsp: implement new slot generation method with fm support
*[209](https://github.com/Yabause/yabause/pull/209): new scsp: implement dsp
*[211](https://github.com/Yabause/yabause/pull/211): vidsoft: improve sprite window bounds checking
*[212](https://github.com/Yabause/yabause/pull/212): new scsp: implement mixing, cd audio, dsp saturation
*[213](https://github.com/Yabause/yabause/pull/213): new scsp/qt :improve send levels and add channel debug dialog

