### PR TITLE
libretro: Fix undefined pthread references (with GCC)

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -51,7 +51,8 @@ ifneq (,$(findstring unix,$(platform)))
 	fpic := -fPIC
 	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
 	#DYNAREC = 2
-	LDFLAGS += -lpthread
+	FLAGS += -pthread
+	LDFLAGS += -pthread
 	HAVE_PTHREADS = 1
 
 else ifneq (,$(findstring linux-portable,$(platform)))
@@ -71,7 +72,8 @@ ifeq ($(arch),ppc)
 	ENDIANNESS_DEFINES := -DWORDS_BIGENDIAN -DMSB_FIRST -D__ppc__
 endif
 	#DYNAREC = 2
-	LDFLAGS += -lpthread
+	FLAGS += -pthread
+	LDFLAGS += -pthread
 	HAVE_PTHREADS = 1
 
 else ifneq (,$(findstring theos_ios,$(platform)))
@@ -181,7 +183,8 @@ else ifneq (,$(findstring armv,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-	LDFLAGS += -lpthread
+	FLAGS += -pthread
+	LDFLAGS += -pthread
 	HAVE_PTHREADS = 1
 	ifneq (,$(findstring cortexa8,$(platform)))
 		FLAGS += -marm -mcpu=cortex-a8


### PR DESCRIPTION
Compilation with GCC (7.3 on Ubunto Bionic) leads to:

```
./thr-unix.o: In function `wrapper':
thr-unix.c:(.text+0x1f): undefined reference to `pthread_setspecific'
./thr-unix.o: In function `YabThreadStart':
thr-unix.c:(.text+0x7c): undefined reference to `pthread_once'
thr-unix.c:(.text+0xe8): undefined reference to `pthread_create'
./thr-unix.o: In function `YabThreadWait':
thr-unix.c:(.text+0x20d): undefined reference to `pthread_join'
./thr-unix.o: In function `YabThreadSleep':
thr-unix.c:(.text+0x26b): undefined reference to `pthread_getspecific'
./thr-unix.o: In function `make_key':
thr-unix.c:(.text+0x4a): undefined reference to `pthread_key_create'
```

GCC expects libraries to be mentioned after the compilation units and therefore `-lpthread` would have to be added to `LIBS` instead of `LDFLAGS`.

However for GCC it seems to be the correct way to specify `-pthread` (for both compiler and linker). This is compatible also with clang (verified with clang 6.0).