### PR TITLE
(fix) Remove file_stream_transform

### DIFF
--- a/yabause/src/cdbase.c
+++ b/yabause/src/cdbase.c
@@ -34,9 +34,9 @@
 
 #include <stdarg.h>
 
-#ifdef __LIBRETRO__
-#include "streams/file_stream_transforms.h"
-#endif
+//#ifdef __LIBRETRO__
+//#include "streams/file_stream_transforms.h"
+//#endif
 
 #ifndef HAVE_STRICMP
 #ifdef HAVE_STRCASECMP


### PR DESCRIPTION
As far as i know, the core hangs in windows because of this (same issue as kronos, i think it was mentioned by @tatsuya79 on discord a few days ago)