### PR TITLE
libretro: jni: Fix compile

### DIFF
--- a/yabause/src/libretro/jni/Application.mk
+++ b/yabause/src/libretro/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_STL := c++_static
 APP_ABI := all
-APP_PLATFORM := android-21
+APP_PLATFORM := android-24

--- a/yabause/src/musashi/m68kcpu.c
+++ b/yabause/src/musashi/m68kcpu.c
@@ -562,7 +562,9 @@ void m68k_set_instr_hook_callback(void  (*callback)(void))
 	CALLBACK_INSTR_HOOK = callback ? callback : default_instr_hook_callback;
 }
 
+#ifndef ANDROID
 #include <stdio.h>
+#endif
 /* Set the CPU type. */
 void m68k_set_cpu_type(unsigned int cpu_type)
 {


### PR DESCRIPTION
Newer clang errors on attempts to redefine built-in types

pthread barriers are only supported on api >= 24