### PR TITLE
fix building by disabling PlayRecorder functionality on libretro

### DIFF
--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -186,9 +186,11 @@ int YabauseInit(yabauseinit_struct *init)
   q_scsp_finish = YabThreadCreateQueue(1);
   setM68kCounter(0);
 
+#ifndef __LIBRETRO__
   if( init->playRecordPath && strlen(init->playRecordPath) != 0) {
     PlayRecorder_setPlayMode(init->playRecordPath,init);
   }
+#endif
 
    yabsys.frame_count = 0;
    yabsys.sync_shift = init->sync_shift;
@@ -641,7 +643,9 @@ u64 g_m68K_dec_cycle = 0;
 int YabauseEmulate(void) {
    int oneframeexec = 0;
    yabsys.frame_count++;
+#ifndef __LIBRETRO__
    PlayRecorder_proc(yabsys.frame_count);
+#endif
 
    const u32 cyclesinc =
       yabsys.DecilineMode ? yabsys.DecilineStop : yabsys.DecilineStop * 10;


### PR DESCRIPTION
 * doesn't seem required for the libretro core and needs g++ 8 due to std::filesystem