### PR TITLE
Add riscv64 support

### DIFF
--- a/yabause/src/libretro/Makefile
+++ b/yabause/src/libretro/Makefile
@@ -108,6 +108,11 @@ ifneq (,$(findstring unix,$(platform)))
 		FLAGS += -DARM
 	endif
 
+	# riscv64
+	ifneq ($(findstring riscv64,$(shell uname -a)),)
+		HAVE_SSE = 0
+	endif
+
 else ifneq (,$(findstring linux-portable,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC -nostdlib


### PR DESCRIPTION
I build the software in riscv64 environment and I get the following error.

```
cc: error: unrecognized command-line option -mfpmath=sse
make: *** [Makefile:646: ../bios.c.o] Error 1
make: *** Waiting for unfinished jobs....
cc: error: unrecognized command-line option -mfpmath=sse
cc: error: unrecognized command-line option -mfpmath=sse
cc: error: unrecognized command-line option -mfpmath=sse
cc: error: unrecognized command-line option -mfpmath=sse
```

So I specified in the makefile that HAVE_SSE=0 in the riscv64 environment.
This way it compiles properly.