### PR TITLE
Add generic 64-bit Cortex-A53 with GLES 3.0 target

### DIFF
--- a/yabause/src/libretro/Makefile
+++ b/yabause/src/libretro/Makefile
@@ -99,6 +99,20 @@ else ifeq ($(platform), arm64)
 	USE_AARCH64_DRC = 1
 	DYNAREC_DEVMIYAX = 1
 
+# Generic AArch64 Cortex-A53 support with GLES 3.0 like Amlogic G12A or Allwinner H616 
+else ifneq (,$(findstring arm64_cortex_a53_gles3,$(platform)))
+	override platform += unix
+	TARGET := $(TARGET_NAME)_libretro.so
+	fpic := -fPIC
+	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+	LDFLAGS += -lpthread
+	ARCH_IS_LINUX = 1
+	HAVE_SSE = 0
+	FORCE_GLES = 1
+	USE_AARCH64_DRC = 1
+	DYNAREC_DEVMIYAX = 1
+	FLAGS += -DAARCH64 -march=armv8-a+crc+fp+simd -mcpu=cortex-a53 -mtune=cortex-a53
+
 # Amlogic S922X Odroid-N2 / A311D Khadas VIM3 (AMLG12B) - 32-bit userspace
 else ifneq (,$(findstring AMLG12B,$(platform)))
 	override platform += unix


### PR DESCRIPTION
Several  64-bit ARM SoCs are based on Cortex-A53 + GLES 3.0 compliant GPU so add this targe to be able to support, amongst others :
- Amlogic G12A platform (S905gen2 like Radxa Zero)
- Amlogic GXL platform (S912 like Khadas VIM2)
- Allwinner H6 platform (Orange Pi One Plus)
- Allwinner H616 platform (Orange Pi Zero 2)

