### PR TITLE
Add RPi5 build parameter

### DIFF
--- a/yabause/src/libretro/Makefile
+++ b/yabause/src/libretro/Makefile
@@ -176,6 +176,21 @@ else ifeq ($(platform), rpi4)
 	DYNAREC_DEVMIYAX = 1
 	FLAGS += -mcpu=cortex-a72 -mtune=cortex-a72
 
+# Rpi5 (64-bit)
+else ifeq ($(platform), rpi5)
+	override platform += unix
+	TARGET := $(TARGET_NAME)_libretro.so
+	fpic := -fPIC
+	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+	LDFLAGS += -lpthread
+	FLAGS += -DAARCH64
+	ARCH_IS_LINUX = 1
+	HAVE_SSE = 0
+	FORCE_GLES = 1
+	USE_AARCH64_DRC = 1
+	DYNAREC_DEVMIYAX = 1
+	FLAGS += -mcpu=cortex-a76 -mtune=cortex-a76
+
 # ODROIDs
 else ifneq (,$(findstring odroid-c4,$(platform)))
 	override platform += unix


### PR DESCRIPTION
This pull request is for RPi5.

It based on RPi4 build parameters, with the FLAGS -mcpu and  -mtune for RPi5.

Build was finished with no error on Lakka v5.x.
Daytona USA (Japan) was playable on RPi5.

Thanks
ASAI, shigeaki