### PR TITLE
add linux-aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux 64-bit (ARM)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -95,6 +99,12 @@ libretro-build-linux-x64:
 libretro-build-linux-i686:
   extends:
     - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux 64-bit (ARM)
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit

--- a/yabause/src/libretro/Makefile
+++ b/yabause/src/libretro/Makefile
@@ -112,6 +112,12 @@ ifneq (,$(findstring unix,$(platform)))
 		FLAGS += -DARM
 	endif
 
+	# aarch64
+	ifneq ($(findstring aarch64,$(shell uname -a)),)
+		HAVE_SSE = 0
+		FLAGS += -DARM
+	endif
+
 	# riscv64
 	ifneq ($(findstring riscv64,$(shell uname -a)),)
 		HAVE_SSE = 0


### PR DESCRIPTION
Add linux-aarch64 CI build job.

Also adds `aarch64` to the HAVE_SSE detection in the Makefile — `uname -a` includes `aarch64` on Linux, and SSE is x86-only.