### PR TITLE
ci: add Linux aarch64 libretro build (yabasanshiro)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux 64-bit (ARM)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -84,6 +88,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux 64-bit (ARM)
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit

--- a/yabause/src/libretro/Makefile
+++ b/yabause/src/libretro/Makefile
@@ -84,6 +84,14 @@ ifneq (,$(findstring unix,$(platform)))
 		USE_ARM_DRC = 1
 		DYNAREC_DEVMIYAX = 1
 		FLAGS += -DARM
+	# Native AArch64 (ARM64) desktop build (e.g. the libretro linux-aarch64 job,
+	# which invokes `make platform=unix` on an aarch64 runner). Use the devMiyax
+	# AArch64 SH2 dynarec and drop the x86-only SSE math flags.
+	else ifneq (,$(filter aarch64 arm64,$(shell uname -m)))
+		HAVE_SSE = 0
+		USE_AARCH64_DRC = 1
+		DYNAREC_DEVMIYAX = 1
+		FLAGS += -DAARCH64
 	endif
 
 # Switch Lakka (arm64)


### PR DESCRIPTION
## What

Adds a **Linux aarch64** libretro build (this core has an AArch64 SH2 dynarec and already builds for `android-arm64-v8a`, but there was no desktop Linux ARM64 job).

Two parts:

1. **`Makefile`** — a native `make platform=unix` on aarch64 (which is what the libretro `linux-aarch64` job runs) previously fell through to the x86 path and failed immediately with `cc: error: unrecognized command-line option '-mfpmath=sse'`. Detect an aarch64/arm64 host (`uname -m`) and take the devMiyax **AArch64 dynarec** path — `USE_AARCH64_DRC=1`, `DYNAREC_DEVMIYAX=1`, `-DAARCH64`, `HAVE_SSE=0` — mirroring the existing dedicated `arm64`/`*_gles3` platform targets.
2. **`.gitlab-ci.yml`** — add the `/linux-aarch64.yml` include + a `libretro-build-linux-aarch64` job.

## Testing

Built for **aarch64** natively (GCC 15.2, `make platform=unix`): assembles `dynalib_arm64.s` (the AArch64 dynarec) and links cleanly with `-Wl,--no-undefined`. Ran the resulting `yabasanshiro_libretro.so` in RetroArch 1.22 on an aarch64 device (Adreno 618, OpenGL HW render): boots a retail Saturn disc (Daytona USA) through the BIOS to in-game rendering at 60 fps — the AArch64 SH2 dynarec works.
